### PR TITLE
Add HTTP client API

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,13 +20,36 @@ let package = Package(
         .package(
             url: "https://github.com/FranzBusch/swift-collections.git",
             branch: "fb-async"
-        )
+        ),
+        .package(url: "https://github.com/apple/swift-http-types.git", from: "1.5.1"),
     ],
     targets: [
+        .target(
+            name: "HTTPAPIs",
+            dependencies: [
+                "AsyncStreaming",
+                "NetworkTypes",
+                .product(name: "HTTPTypes", package: "swift-http-types"),
+            ],
+            swiftSettings: extraSettings
+        ),
+        .target(
+            name: "NetworkTypes",
+            swiftSettings: extraSettings
+        ),
         .target(
             name: "AsyncStreaming",
             dependencies: [
                 .product(name: "BasicContainers", package: "swift-collections")
+            ],
+            swiftSettings: extraSettings
+        ),
+
+        // MARK: Tests
+        .testTarget(
+            name: "NetworkTypesTests",
+            dependencies: [
+                "NetworkTypes"
             ],
             swiftSettings: extraSettings
         ),

--- a/Sources/HTTPAPIs/Client/DefaultHTTPClientEventHandler.swift
+++ b/Sources/HTTPAPIs/Client/DefaultHTTPClientEventHandler.swift
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP API Proposal open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift HTTP API Proposal project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Security)
+public import Security
+#endif
+
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+public struct DefaultHTTPClientEventHandler: ~Copyable {
+    public init() {}
+}
+
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+struct HTTPClientEventHandlerDefaultImplementationError: Error {
+    init() {}
+}
+
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+extension DefaultHTTPClientEventHandler: HTTPClientEventHandler {
+    public func handleRedirection(
+        response: HTTPResponse,
+        newRequest: HTTPRequest
+    ) async throws -> HTTPClientRedirectionAction {
+        throw HTTPClientEventHandlerDefaultImplementationError()
+    }
+
+    #if canImport(Security)
+    public func handleServerTrust(_ trust: SecTrust) async throws -> HTTPClientTrustResult {
+        throw HTTPClientEventHandlerDefaultImplementationError()
+    }
+    #endif
+}

--- a/Sources/HTTPAPIs/Client/HTTPClient.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClient.swift
@@ -1,0 +1,95 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP API Proposal open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift HTTP API Proposal project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// We are using exported imports so that developers don't have to
+// import multiple modules just to execute an HTTP request
+@_exported public import AsyncStreaming
+@_exported public import HTTPTypes
+
+/// A protocol that defines the interface for an HTTP client.
+///
+/// ``HTTPClient`` provides asynchronous request execution with streaming request
+/// and response bodies.
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+public protocol HTTPClient<RequestWriter, ResponseReader>: ~Copyable {
+    /// The type used to write request body data.
+    associatedtype RequestWriter: ConcludingAsyncWriter, ~Copyable, SendableMetatype
+    where RequestWriter.Underlying.WriteElement == UInt8, RequestWriter.FinalElement == HTTPFields?
+
+    /// The type used to read response body data.
+    associatedtype ResponseReader: ConcludingAsyncReader, ~Copyable, SendableMetatype
+    where ResponseReader.Underlying.ReadElement == UInt8, ResponseReader.FinalElement == HTTPFields?
+
+    /// Performs an HTTP request and processes the response.
+    ///
+    /// This method executes the HTTP request with the specified configuration and event
+    /// handler, then invokes the response handler when the response headers are received.
+    /// The request and response bodies are streamed using the client's writer and reader types.
+    ///
+    /// - Parameters:
+    ///   - request: The HTTP request headers to send.
+    ///   - body: The optional request body to send. When `nil`, no body is sent.
+    ///   - configuration: The configuration settings for this request.
+    ///   - eventHandler: The handler for processing events during request execution.
+    ///   - responseHandler: The closure to process the response. This closure is invoked
+    ///     when the response headers are received and can read the response body.
+    ///
+    /// - Returns: The value returned by the response handler closure.
+    ///
+    /// - Throws: An error if the request fails or if the response handler throws.
+    mutating func perform<Return>(
+        request: HTTPRequest,
+        body: consuming HTTPClientRequestBody<RequestWriter>?,
+        configuration: HTTPClientConfiguration,
+        eventHandler: borrowing some HTTPClientEventHandler & ~Escapable & ~Copyable,
+        responseHandler: (HTTPResponse, consuming ResponseReader) async throws -> Return
+    ) async throws -> Return
+}
+
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+extension HTTPClient {
+    /// Performs an HTTP request and processes the response.
+    ///
+    /// This method executes the HTTP request with the specified configuration and event
+    /// handler, then invokes the response handler when the response headers are received.
+    /// The request and response bodies are streamed using the client's writer and reader types.
+    ///
+    /// - Parameters:
+    ///   - request: The HTTP request headers to send.
+    ///   - body: The optional request body to send. When `nil`, no body is sent.
+    ///   - configuration: The configuration settings for this request.
+    ///   - eventHandler: The handler for processing events during request execution.
+    ///   - responseHandler: The closure to process the response. This closure is invoked
+    ///     when the response headers are received and can read the response body.
+    ///
+    /// - Returns: The value returned by the response handler closure.
+    ///
+    /// - Throws: An error if the request fails or if the response handler throws.
+    public mutating func perform<Return>(
+        request: HTTPRequest,
+        body: consuming HTTPClientRequestBody<RequestWriter>? = nil,
+        configuration: HTTPClientConfiguration = .init(),
+        eventHandler: consuming some HTTPClientEventHandler & ~Escapable & ~Copyable =
+            DefaultHTTPClientEventHandler(),
+        responseHandler: (HTTPResponse, consuming ResponseReader) async throws -> Return,
+    ) async throws -> Return {
+        try await self.perform(
+            request: request,
+            body: body,
+            configuration: configuration,
+            eventHandler: eventHandler,
+            responseHandler: responseHandler
+        )
+    }
+}

--- a/Sources/HTTPAPIs/Client/HTTPClientConfiguration.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClientConfiguration.swift
@@ -1,0 +1,94 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP API Proposal open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift HTTP API Proposal project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+public import NetworkTypes
+
+/// A struct that defines configuration options for an HTTP client.
+///
+/// ``HTTPClientConfiguration`` provides settings for controlling security protocols,
+/// network access policies, and other client behavior. Use this configuration to
+/// customize how the HTTP client establishes connections and handles requests.
+///
+/// ## Example
+///
+/// ```swift
+/// var configuration = HTTPClientConfiguration()
+/// configuration.security.minimumTLSVersion = .v1_3
+/// configuration.path.allowsExpensiveNetworkAccess = false
+/// ```
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+public struct HTTPClientConfiguration: Sendable {
+    /// A struct that defines security-related configuration options.
+    ///
+    /// ``Security`` specifies TLS version requirements and other security policies
+    /// for HTTP client connections.
+    public struct Security: Sendable {
+        /// The minimum TLS protocol version allowed for connections.
+        ///
+        /// Connections using TLS versions below this value are rejected.
+        /// The default value is TLS 1.2.
+        public var minimumTLSVersion: TLSVersion = .v1_2
+
+        /// The maximum TLS protocol version allowed for connections.
+        ///
+        /// Connections using TLS versions above this value are rejected.
+        /// The default value is TLS 1.3.
+        public var maximumTLSVersion: TLSVersion = .v1_3
+
+        /// Creates a security configuration with default values.
+        ///
+        /// The default configuration allows TLS 1.2 and TLS 1.3 connections.
+        public init() {}
+    }
+
+    /// A struct that defines network path configuration options.
+    ///
+    /// ``Path`` specifies network access policies including constraints for
+    /// expensive and limited network connections.
+    public struct Path: Sendable {
+        /// A Boolean value that indicates whether the client allows connections over expensive networks.
+        ///
+        /// When `true`, the client can establish connections over networks marked as expensive,
+        /// such as cellular data or personal hotspots. When `false`, the client only uses
+        /// inexpensive networks like Wi-Fi. The default value is `true`.
+        public var allowsExpensiveNetworkAccess: Bool = true
+
+        /// A Boolean value that indicates whether the client allows connections over constrained networks.
+        ///
+        /// When `true`, the client can establish connections over networks marked as constrained,
+        /// such as networks in Low Data Mode. When `false`, the client avoids constrained networks.
+        /// The default value is `true`.
+        public var allowsConstrainedNetworkAccess: Bool = true
+
+        /// Creates a network path configuration with default values.
+        ///
+        /// The default configuration allows both expensive and constrained network access.
+        public init() {}
+    }
+
+    /// The security configuration for the HTTP client.
+    ///
+    /// This property controls TLS version requirements and other security policies
+    /// for client connections.
+    public var security: Security = .init()
+
+    /// The network path configuration for the HTTP client.
+    ///
+    /// This property controls network access policies including expensive and
+    /// constrained network handling.
+    public var path: Path = .init()
+
+    /// Creates an HTTP client configuration with default values.
+    public init() {}
+}

--- a/Sources/HTTPAPIs/Client/HTTPClientEventHandler.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClientEventHandler.swift
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP API Proposal open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift HTTP API Proposal project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+public import Security
+#endif
+
+/// A protocol that defines event handling methods for HTTP client operations.
+///
+/// ``HTTPClientEventHandler`` allows custom handling of HTTP redirections and server
+/// trust evaluations during client request processing. Conforming types can implement
+/// custom logic for these events to control client behavior.
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+public protocol HTTPClientEventHandler: ~Escapable, ~Copyable {
+    /// Handles 3xx redirection responses received by the HTTP client.
+    ///
+    /// This method is called when the client receives a redirect response, allowing
+    /// custom logic to determine whether to follow the redirect or deliver the
+    /// redirect response to the caller.
+    ///
+    /// - Parameters:
+    ///   - response: The 3xx HTTP response that triggered the redirection.
+    ///   - newRequest: The suggested new request for following the redirection.
+    ///
+    /// - Returns: An ``HTTPClientRedirectionAction`` indicating whether to follow
+    ///   the redirect or deliver the redirect response.
+    ///
+    /// - Throws: An error if the redirection handling fails.
+    func handleRedirection(
+        response: HTTPResponse,
+        newRequest: HTTPRequest
+    ) async throws -> HTTPClientRedirectionAction
+
+    #if canImport(Darwin)
+    /// Handles the server trust challenge during the TLS handshake.
+    ///
+    /// This method is called when the client needs to evaluate the server's certificate
+    /// during TLS connection establishment. Implementations can perform custom certificate
+    /// validation or trust evaluation logic.
+    ///
+    /// - Parameter trust: The server trust object containing the certificate chain to evaluate.
+    ///
+    /// - Returns: An ``HTTPClientTrustResult`` indicating whether to use default trust
+    ///   evaluation, explicitly allow, or explicitly deny the connection.
+    ///
+    /// - Throws: An error if the trust evaluation fails.
+    // TODO: Can we introduce a more cross-platform way for this?
+    func handleServerTrust(_ trust: SecTrust) async throws -> HTTPClientTrustResult
+    #endif
+}

--- a/Sources/HTTPAPIs/Client/HTTPClientRedirectionAction.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClientRedirectionAction.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP API Proposal open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift HTTP API Proposal project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// An enumeration that represents the action to take when handling HTTP redirections.
+///
+/// ``HTTPClientRedirectionAction`` specifies whether to follow a redirect to a new location
+/// or deliver the original redirect response to the caller.
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+public enum HTTPClientRedirectionAction: Sendable {
+    /// Follows the HTTP redirection by performing the new request.
+    ///
+    /// The associated ``HTTPRequest`` value contains the request to perform for the redirection.
+    /// The client automatically handles the redirect and processes the new response.
+    case follow(HTTPRequest)
+
+    /// Delivers the redirection response without following the redirect.
+    ///
+    /// When this action is taken, the client returns the original 3xx redirect response
+    /// instead of automatically following it. This allows the caller to inspect the
+    /// redirect response or handle it manually.
+    case deliverRedirectionResponse
+}

--- a/Sources/HTTPAPIs/Client/HTTPClientRequestBody.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClientRequestBody.swift
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP API Proposal open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift HTTP API Proposal project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import AsyncStreaming
+
+/// An enumeration that represents the body of an HTTP client request.
+///
+/// ``HTTPClientRequestBody`` provides two strategies for streaming request body data:
+/// restartable bodies that can be replayed from the beginning for retries or redirects,
+/// and seekable bodies that support resuming from a specific byte offset.
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+public enum HTTPClientRequestBody<Writer>: Sendable, ~Copyable
+where Writer: ConcludingAsyncWriter & ~Copyable, Writer.Underlying.WriteElement == UInt8, Writer.FinalElement == HTTPFields?, Writer: SendableMetatype
+{
+    /// A restartable request body that can be replayed from the beginning.
+    ///
+    /// This case is used when the client may need to retry or follow redirects with
+    /// the same request body. The closure receives a writer and streams the entire
+    /// body content. The closure may be called multiple times if the request needs
+    /// to be retried.
+    ///
+    /// - Parameter writer: The closure that writes the request body using the provided writer.
+    case restartable(@Sendable (consuming Writer) async throws -> Void)
+
+    /// A seekable request body that supports resuming from a specific byte offset.
+    ///
+    /// This case is used for resumable uploads where the client can start streaming
+    /// from a specific position in the body. The closure receives an offset indicating
+    /// where to begin writing and a writer for streaming the body content.
+    ///
+    /// - Parameters:
+    ///   - offset: The byte offset from which to start writing the body.
+    ///   - writer: The closure that writes the request body using the provided writer.
+    case seekable(@Sendable (Int64, consuming Writer) async throws -> Void)
+}

--- a/Sources/HTTPAPIs/Client/HTTPClientTrustResult.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClientTrustResult.swift
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP API Proposal open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift HTTP API Proposal project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+/// An enumeration that represents the action to take when evaluating server trust during TLS handshake.
+///
+/// ``HTTPClientTrustResult`` specifies whether to use the system's default trust evaluation,
+/// explicitly allow the connection, or explicitly deny it.
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+public enum HTTPClientTrustResult {
+    /// Uses the system's default trust evaluation for the server certificate.
+    ///
+    /// The system evaluates the server's certificate chain using standard trust policies
+    /// and certificate validation rules.
+    case `default`
+
+    /// Allows the connection regardless of trust evaluation results.
+    ///
+    /// When this action is taken, the client proceeds with the connection even if
+    /// the server's certificate would normally fail validation. Use with caution as
+    /// this bypasses security checks.
+    case allow
+
+    /// Denies the connection regardless of trust evaluation results.
+    ///
+    /// When this action is taken, the client refuses the connection even if
+    /// the server's certificate passes standard validation. This can be used to
+    /// enforce additional security policies beyond system defaults.
+    case deny
+}
+#endif

--- a/Sources/NetworkTypes/TLSVersion.swift
+++ b/Sources/NetworkTypes/TLSVersion.swift
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP API Proposal open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift HTTP API Proposal project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// A struct that represents a TLS protocol version.
+///
+/// ``TLSVersion`` provides type-safe access to supported TLS protocol versions
+/// for secure network communication.
+public struct TLSVersion: Sendable, Hashable {
+    private let rawValue: UInt16
+
+    private init?(rawValue: UInt16) {
+        self.rawValue = rawValue
+    }
+
+    /// The TLS 1.2 protocol version.
+    ///
+    /// TLS 1.2 is defined in RFC 5246 and uses protocol version 0x0303.
+    public static var v1_2: TLSVersion {
+        .init(rawValue: 0x0303)!
+    }
+
+    /// The TLS 1.3 protocol version.
+    ///
+    /// TLS 1.3 is defined in RFC 8446 and uses protocol version 0x0304.
+    public static var v1_3: TLSVersion {
+        .init(rawValue: 0x0304)!
+    }
+}

--- a/Tests/NetworkTypesTests/TLSVersionTests.swift
+++ b/Tests/NetworkTypesTests/TLSVersionTests.swift
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP API Proposal open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift HTTP API Proposal project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NetworkTypes
+import Testing
+
+@Suite
+struct TLSVersionTests {
+    @Test
+    func versionsAreDistinct() {
+        let v1_2 = TLSVersion.v1_2
+        let v1_3 = TLSVersion.v1_3
+
+        #expect(v1_2 != v1_3)
+    }
+
+    @Test
+    func equalityWorks() {
+        let v1_2_first = TLSVersion.v1_2
+        let v1_2_second = TLSVersion.v1_2
+
+        #expect(v1_2_first == v1_2_second)
+    }
+
+    @Test
+    func hashableConformance() {
+        let v1_2 = TLSVersion.v1_2
+        let v1_3 = TLSVersion.v1_3
+
+        // Test that different versions have different hash values
+        // Note: This is not guaranteed by Hashable but is expected in practice
+        #expect(v1_2.hashValue != v1_3.hashValue)
+
+        // Test that same version has same hash value
+        #expect(v1_2.hashValue == TLSVersion.v1_2.hashValue)
+        #expect(v1_3.hashValue == TLSVersion.v1_3.hashValue)
+    }
+}


### PR DESCRIPTION
This PR adds a new protocol and related types to model an HTTP client capable of bi-directional streaming and trailers.
