### PR TITLE
Add HTTP server API

### DIFF
--- a/Sources/HTTPAPIs/Client/HTTPClient.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClient.swift
@@ -22,14 +22,14 @@
 /// ``HTTPClient`` provides asynchronous request execution with streaming request
 /// and response bodies.
 @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
-public protocol HTTPClient<RequestWriter, ResponseReader>: ~Copyable {
-    /// The type used to write request body data.
-    associatedtype RequestWriter: ConcludingAsyncWriter, ~Copyable, SendableMetatype
-    where RequestWriter.Underlying.WriteElement == UInt8, RequestWriter.FinalElement == HTTPFields?
+public protocol HTTPClient<RequestConcludingWriter, ResponseConcludingReader>: ~Copyable {
+    /// The type used to write request body data and trailers.
+    associatedtype RequestConcludingWriter: ConcludingAsyncWriter, ~Copyable, SendableMetatype
+    where RequestConcludingWriter.Underlying.WriteElement == UInt8, RequestConcludingWriter.FinalElement == HTTPFields?
 
-    /// The type used to read response body data.
-    associatedtype ResponseReader: ConcludingAsyncReader, ~Copyable, SendableMetatype
-    where ResponseReader.Underlying.ReadElement == UInt8, ResponseReader.FinalElement == HTTPFields?
+    /// The type used to read response body data and trailers.
+    associatedtype ResponseConcludingReader: ConcludingAsyncReader, ~Copyable, SendableMetatype
+    where ResponseConcludingReader.Underlying.ReadElement == UInt8, ResponseConcludingReader.FinalElement == HTTPFields?
 
     /// Performs an HTTP request and processes the response.
     ///
@@ -50,10 +50,10 @@ public protocol HTTPClient<RequestWriter, ResponseReader>: ~Copyable {
     /// - Throws: An error if the request fails or if the response handler throws.
     mutating func perform<Return>(
         request: HTTPRequest,
-        body: consuming HTTPClientRequestBody<RequestWriter>?,
+        body: consuming HTTPClientRequestBody<RequestConcludingWriter>?,
         configuration: HTTPClientConfiguration,
         eventHandler: borrowing some HTTPClientEventHandler & ~Escapable & ~Copyable,
-        responseHandler: (HTTPResponse, consuming ResponseReader) async throws -> Return
+        responseHandler: (HTTPResponse, consuming ResponseConcludingReader) async throws -> Return
     ) async throws -> Return
 }
 
@@ -78,11 +78,11 @@ extension HTTPClient {
     /// - Throws: An error if the request fails or if the response handler throws.
     public mutating func perform<Return>(
         request: HTTPRequest,
-        body: consuming HTTPClientRequestBody<RequestWriter>? = nil,
+        body: consuming HTTPClientRequestBody<RequestConcludingWriter>? = nil,
         configuration: HTTPClientConfiguration = .init(),
         eventHandler: consuming some HTTPClientEventHandler & ~Escapable & ~Copyable =
             DefaultHTTPClientEventHandler(),
-        responseHandler: (HTTPResponse, consuming ResponseReader) async throws -> Return,
+        responseHandler: (HTTPResponse, consuming ResponseConcludingReader) async throws -> Return,
     ) async throws -> Return {
         try await self.perform(
             request: request,

--- a/Sources/HTTPAPIs/Server/HTTPRequestContext.swift
+++ b/Sources/HTTPAPIs/Server/HTTPRequestContext.swift
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP API Proposal open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift HTTP API Proposal project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// A context object that carries additional information about an HTTP request.
+///
+/// `HTTPRequestContext` provides a way to pass metadata through the HTTP request pipeline.
+public struct HTTPRequestContext: Sendable {}

--- a/Sources/HTTPAPIs/Server/HTTPServer.swift
+++ b/Sources/HTTPAPIs/Server/HTTPServer.swift
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP API Proposal open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift HTTP API Proposal project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+/// A protocol that defines the interface for an HTTP server.
+///
+/// ``HTTPServerProtocol`` provides the contract for server implementations that accept
+/// incoming HTTP connections and process requests using a ``HTTPServerRequestHandler``.
+public protocol HTTPServer<RequestConcludingReader, ResponseConcludingWriter>: Sendable, ~Copyable, ~Escapable {
+    /// The type used to read request body data and trailers.
+    associatedtype RequestConcludingReader: ConcludingAsyncReader, ~Copyable, SendableMetatype
+    where RequestConcludingReader.Underlying.ReadElement == UInt8, RequestConcludingReader.FinalElement == HTTPFields?
+
+    /// The type used to write response body data and trailers.
+    associatedtype ResponseConcludingWriter: ConcludingAsyncWriter, ~Copyable, SendableMetatype
+    where ResponseConcludingWriter.Underlying.WriteElement == UInt8, ResponseConcludingWriter.FinalElement == HTTPFields?
+
+    /// Starts an HTTP server with the specified request handler.
+    ///
+    /// This method creates and runs an HTTP server that processes incoming requests using the provided
+    /// ``HTTPServerRequestHandler`` implementation.
+    ///
+    /// Implementations of this method should handle each connection concurrently using Swift's structured concurrency.
+    ///
+    /// - Parameters:
+    ///   - handler: A ``HTTPServerRequestHandler`` implementation that processes incoming HTTP requests. The handler
+    ///     receives each request along with a body reader and ``HTTPResponseSender``.
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// let server = // create an instance of a type conforming to the `ServerProtocol`
+    /// try await server.serve(handler: YourRequestHandler())
+    /// ```
+    func serve(handler: some HTTPServerRequestHandler<RequestConcludingReader, ResponseConcludingWriter>) async throws
+}

--- a/Sources/HTTPAPIs/Server/HTTPServerClosureRequestHandler.swift
+++ b/Sources/HTTPAPIs/Server/HTTPServerClosureRequestHandler.swift
@@ -1,0 +1,135 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP API Proposal open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift HTTP API Proposal project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+public import HTTPTypes
+
+/// A closure-based implementation of ``HTTPServerRequestHandler``.
+///
+/// ``HTTPServerClosureRequestHandler`` provides a convenient way to create an HTTP request handler
+/// using a closure instead of conforming a custom type to the ``HTTPServerRequestHandler`` protocol.
+/// This is useful for simple handlers or when you need to create handlers dynamically.
+///
+/// - Example:
+/// ```swift
+/// let echoHandler = HTTPServerClosureRequestHandler { request, context, bodyReader, responseSender in
+///     // Read the entire request body
+///     let (bodyData, _) = try await bodyReader.consumeAndConclude { reader in
+///         // ... body reading code ...
+///     }
+///
+///     // Create and send response
+///     var response = HTTPResponse(status: .ok)
+///     let responseWriter = try await responseSender.send(response)
+///     try await responseWriter.produceAndConclude { writer in
+///         try await writer.write(bodyData.span)
+///         return ((), nil)
+///     }
+/// }
+/// ```
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+public struct HTTPServerClosureRequestHandler<
+    RequestReader: ConcludingAsyncReader & ~Copyable,
+    ResponseWriter: ConcludingAsyncWriter & ~Copyable,
+>: HTTPServerRequestHandler
+where
+    RequestReader.Underlying.ReadElement == UInt8,
+    ResponseWriter.Underlying.WriteElement == UInt8,
+    RequestReader.FinalElement == HTTPFields?,
+    ResponseWriter.FinalElement == HTTPFields?
+{
+    /// The underlying closure that handles HTTP requests.
+    private let _handler:
+        nonisolated(nonsending) @Sendable (
+            HTTPRequest,
+            HTTPRequestContext,
+            consuming sending RequestReader,
+            consuming sending HTTPResponseSender<ResponseWriter>
+        ) async throws -> Void
+
+    /// Creates a new closure-based HTTP request handler.
+    ///
+    /// - Parameter handler: A closure that will be called to handle each incoming HTTP request.
+    ///   The closure takes the same parameters as the
+    ///   ``HTTPServerRequestHandler/handle(request:requestContext:requestBodyAndTrailers:responseSender:)`` method.
+    public init(
+        handler:
+            nonisolated(nonsending) @Sendable @escaping (
+                HTTPRequest,
+                HTTPRequestContext,
+                consuming sending RequestReader,
+                consuming sending HTTPResponseSender<ResponseWriter>
+            ) async throws -> Void
+    ) {
+        self._handler = handler
+    }
+
+    /// Handles an incoming HTTP request by delegating to the closure provided at initialization.
+    ///
+    /// This method simply forwards all parameters to the handler closure.
+    ///
+    /// - Parameters:
+    ///   - request: The HTTP request headers and metadata.
+    ///   - requestContext: A ``HTTPRequestContext``.
+    ///   - requestBodyAndTrailers: A reader for accessing the request body data and trailing headers.
+    ///   - responseSender: An ``HTTPResponseSender`` to send the HTTP response.
+    public func handle(
+        request: HTTPRequest,
+        requestContext: HTTPRequestContext,
+        requestBodyAndTrailers: consuming sending RequestReader,
+        responseSender: consuming sending HTTPResponseSender<ResponseWriter>
+    ) async throws {
+        try await self._handler(request, requestContext, requestBodyAndTrailers, responseSender)
+    }
+}
+
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+extension HTTPServer where RequestConcludingReader.Underlying: Escapable, ResponseConcludingWriter.Underlying: Escapable {
+    /// Starts an HTTP server with a closure-based request handler.
+    ///
+    /// This method provides a convenient way to start an HTTP server using a closure to handle incoming requests.
+    ///
+    /// - Parameters:
+    ///   - handler: An async closure that processes HTTP requests. The closure receives:
+    ///     - `HTTPRequest`: The incoming HTTP request with headers and metadata.
+    ///     - ``HTTPRequestContext``: The request's context.
+    ///     - ``HTTPRequestConcludingAsyncReader``: An async reader for consuming the request body and trailers.
+    ///     - ``HTTPResponseSender``: A non-copyable wrapper for a function that accepts an `HTTPResponse` and provides access to an ``HTTPResponseConcludingAsyncWriter``.
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// try await server.serve { request, bodyReader, responseSender in
+    ///     // Process the request
+    ///     let response = HTTPResponse(status: .ok)
+    ///     let writer = try await responseSender.send(response)
+    ///     try await writer.produceAndConclude { writer in
+    ///         try await writer.write("Hello, World!".utf8)
+    ///         return ((), nil)
+    ///     }
+    /// }
+    /// ```
+    public func serve(
+        handler:
+            @Sendable @escaping (
+                _ request: HTTPRequest,
+                _ requestContext: HTTPRequestContext,
+                _ requestBodyAndTrailers: consuming sending RequestConcludingReader,
+                _ responseSender: consuming sending HTTPResponseSender<ResponseConcludingWriter>
+            ) async throws -> Void
+    ) async throws {
+        try await self.serve(
+            handler: HTTPServerClosureRequestHandler(handler: handler)
+        )
+    }
+}

--- a/Sources/HTTPAPIs/Server/HTTPServerRequestHandler.swift
+++ b/Sources/HTTPAPIs/Server/HTTPServerRequestHandler.swift
@@ -1,0 +1,94 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP API Proposal open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift HTTP API Proposal project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+public import HTTPTypes
+
+/// A protocol that defines the contract for handling HTTP server requests.
+///
+/// ``HTTPServerRequestHandler`` provides a structured way to process incoming HTTP requests
+/// and generate appropriate responses. Conforming types implement the
+/// ``handle(request:requestContext:requestBodyAndTrailers:responseSender:)`` method, which is
+/// called by the HTTP server for each incoming request. The handler is responsible for reading
+/// the request body, processing the request, and sending a response.
+///
+/// This protocol fully supports bidirectional streaming HTTP request handling, including
+/// optional request and response trailers.
+///
+/// # Example
+///
+/// ```swift
+/// struct EchoHandler<
+///     ConcludingRequestReader: ConcludingAsyncReader<RequestReader, HTTPFields?> & ~Copyable,
+///     RequestReader: AsyncReader<UInt8, any Error> & ~Copyable,
+///     ConcludingResponseWriter: ConcludingAsyncWriter<RequestWriter, HTTPFields?> & ~Copyable,
+///     RequestWriter: AsyncWriter<UInt8, any Error> & ~Copyable
+/// >: HTTPServerRequestHandler {
+///     func handle(
+///         request: HTTPRequest,
+///         requestContext: HTTPRequestContext,
+///         requestBodyAndTrailers: consuming sending ConcludingRequestReader,
+///         responseSender: consuming sending HTTPResponseSender<ConcludingResponseWriter>
+///     ) async throws {
+///         var responseSender: HTTPResponseSender<ConcludingResponseWriter>? = responseSender
+///         _ = try await requestBodyAndTrailers.consumeAndConclude { reader in
+///             var reader: RequestReader? = reader
+///             let responseBodyAndTrailers = try await responseSender.take()!.send(
+///                 .init(status: .ok)
+///             )
+///             try await responseBodyAndTrailers.produceAndConclude { writer in
+///                 var writer = writer
+///                 try await reader.take()!.forEach { span in
+///                     try await writer.write(span)
+///                 }
+///                 return ((), nil)
+///             }
+///         }
+///     }
+/// }
+/// ```
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+public protocol HTTPServerRequestHandler<RequestReader, ResponseWriter>: Sendable {
+    /// The type used to read request body data and trailers.
+    associatedtype RequestReader: ConcludingAsyncReader, ~Copyable
+    where RequestReader.Underlying.ReadElement == UInt8, RequestReader.FinalElement == HTTPFields?
+
+    /// The type used to write response body data and trailers.
+    associatedtype ResponseWriter: ConcludingAsyncWriter, ~Copyable
+    where ResponseWriter.Underlying.WriteElement == UInt8, ResponseWriter.FinalElement == HTTPFields?
+
+    /// Handles an incoming HTTP request and generates a response.
+    ///
+    /// This method is called by the HTTP server for each incoming client request. Implementations should:
+    /// 1. Examine the request headers in the `request` parameter.
+    /// 2. Read the request body data from the `requestBodyAndTrailers` reader as needed.
+    /// 3. Process the request and prepare a response.
+    /// 4. Optionally call ``HTTPResponseSender/sendInformational(_:)`` for informational responses.
+    /// 5. Call ``HTTPResponseSender/send(_:)`` with the final HTTP response.
+    /// 6. Write the response body data to the returned writer.
+    ///
+    /// - Parameters:
+    ///   - request: The HTTP request headers and metadata.
+    ///   - requestContext: A ``HTTPRequestContext`` carrying additional request information.
+    ///   - requestBodyAndTrailers: A reader for accessing the request body data and trailing headers.
+    ///   - responseSender: An ``HTTPResponseSender`` that accepts an HTTP response and returns a writer for the
+    ///     response body. The returned writer allows for incremental writing of the response body and supports trailers.
+    ///
+    /// - Throws: Any error encountered during request processing or response generation.
+    func handle(
+        request: HTTPRequest,
+        requestContext: HTTPRequestContext,
+        requestBodyAndTrailers: consuming sending RequestReader,
+        responseSender: consuming sending HTTPResponseSender<ResponseWriter>
+    ) async throws
+}

--- a/Sources/HTTPAPIs/Server/HTTPServerResponseSender.swift
+++ b/Sources/HTTPAPIs/Server/HTTPServerResponseSender.swift
@@ -1,0 +1,76 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP API Proposal open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift HTTP API Proposal project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+public import HTTPTypes
+
+/// A struct that ensures a single non-informational HTTP response is sent per request.
+///
+/// ``HTTPResponseSender`` enforces structured response handling by allowing only one call to
+/// ``send(_:)`` before the sender is consumed. Informational responses can be sent zero or
+/// more times using ``sendInformational(_:)`` before sending the final response. This design
+/// ensures proper HTTP semantics where exactly one non-informational response is sent, followed
+/// by optional response body streaming and trailers.
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+public struct HTTPResponseSender<ResponseWriter: ConcludingAsyncWriter & ~Copyable>: ~Copyable {
+    private let _sendInformational: (HTTPResponse) async throws -> Void
+    private let _send: (HTTPResponse) async throws -> ResponseWriter
+
+    /// Creates a new HTTP response sender.
+    ///
+    /// - Parameters:
+    ///   - send: A closure that sends the final HTTP response and returns a writer for the response body.
+    ///   - sendInformational: A closure that sends informational (1xx) HTTP responses.
+    public init(
+        send: @escaping (HTTPResponse) async throws -> ResponseWriter,
+        sendInformational: @escaping (HTTPResponse) async throws -> Void
+    ) {
+        self._send = send
+        self._sendInformational = sendInformational
+    }
+
+    /// Sends the final HTTP response and returns a writer for the response body.
+    ///
+    /// This method consumes the sender, ensuring only one non-informational response can be sent.
+    /// After calling this method, the sender cannot be used again. For informational (1xx) responses,
+    /// use ``sendInformational(_:)`` instead.
+    ///
+    /// - Parameter response: The final HTTP response to send to the client. Must not be an
+    ///   informational (1xx) response.
+    ///
+    /// - Returns: A writer for streaming the response body data and optional trailers.
+    ///
+    /// - Throws: An error if sending the response fails.
+    consuming public func send(_ response: HTTPResponse) async throws -> ResponseWriter {
+        precondition(response.status.kind != .informational)
+        return try await self._send(response)
+    }
+
+    /// Sends an informational HTTP response.
+    ///
+    /// This method can be called multiple times to send informational (1xx) responses before
+    /// sending the final response with ``send(_:)``. Common informational responses include
+    /// 100 Continue, 102 Processing, and 103 Early Hints.
+    ///
+    /// - Parameter response: An informational HTTP response to send to the client. Must be a
+    ///   1xx status response.
+    ///
+    /// - Throws: An error if sending the informational response fails.
+    public func sendInformational(_ response: HTTPResponse) async throws {
+        precondition(response.status.kind == .informational)
+        return try await _sendInformational(response)
+    }
+}
+
+@available(*, unavailable)
+extension HTTPResponseSender: Sendable {}


### PR DESCRIPTION
This PR adds a new protocol and related types to model an HTTP server capable of bi-directional streaming and trailers.
