### PR TITLE
Add a `URLSession` based `HTTPClient`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,12 @@ let extraSettings: [SwiftSetting] = [
 ]
 let package = Package(
     name: "HTTPAPIProposal",
+    products: [
+        .library(name: "HTTPAPIs", targets: ["HTTPAPIs"]),
+        .library(name: "HTTPClient", targets: ["HTTPClient"]),
+        .library(name: "AsyncStreaming", targets: ["AsyncStreaming"]),
+        .library(name: "NetworkTypes", targets: ["NetworkTypes"]),
+    ],
     dependencies: [
         .package(
             url: "https://github.com/FranzBusch/swift-collections.git",
@@ -30,6 +36,17 @@ let package = Package(
                 "AsyncStreaming",
                 "NetworkTypes",
                 .product(name: "HTTPTypes", package: "swift-http-types"),
+            ],
+            swiftSettings: extraSettings
+        ),
+        .target(
+            name: "HTTPClient",
+            dependencies: [
+                "HTTPAPIs",
+                "AsyncStreaming",
+                "NetworkTypes",
+                .product(name: "HTTPTypes", package: "swift-http-types"),
+                .product(name: "HTTPTypesFoundation", package: "swift-http-types"),
             ],
             swiftSettings: extraSettings
         ),
@@ -57,6 +74,13 @@ let package = Package(
             name: "AsyncStreamingTests",
             dependencies: [
                 "AsyncStreaming"
+            ],
+            swiftSettings: extraSettings
+        ),
+        .testTarget(
+            name: "HTTPClientTests",
+            dependencies: [
+                "HTTPClient"
             ],
             swiftSettings: extraSettings
         ),

--- a/Sources/HTTPAPIs/Client/DefaultHTTPClientEventHandler.swift
+++ b/Sources/HTTPAPIs/Client/DefaultHTTPClientEventHandler.swift
@@ -22,7 +22,9 @@ public struct DefaultHTTPClientEventHandler: ~Copyable {
 }
 
 @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
-struct HTTPClientEventHandlerDefaultImplementationError: Error {
+// TODO: Evaluate if this type should be public and if the default implementations
+// should really throw an error
+public struct HTTPClientEventHandlerDefaultImplementationError: Error {
     init() {}
 }
 

--- a/Sources/HTTPAPIs/Client/HTTPClient.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClient.swift
@@ -48,7 +48,7 @@ public protocol HTTPClient<RequestConcludingWriter, ResponseConcludingReader>: ~
     /// - Returns: The value returned by the response handler closure.
     ///
     /// - Throws: An error if the request fails or if the response handler throws.
-    mutating func perform<Return>(
+    func perform<Return>(
         request: HTTPRequest,
         body: consuming HTTPClientRequestBody<RequestConcludingWriter>?,
         configuration: HTTPClientConfiguration,
@@ -76,7 +76,7 @@ extension HTTPClient where Self: ~Copyable {
     /// - Returns: The value returned by the response handler closure.
     ///
     /// - Throws: An error if the request fails or if the response handler throws.
-    public mutating func perform<Return>(
+    public func perform<Return>(
         request: HTTPRequest,
         body: consuming HTTPClientRequestBody<RequestConcludingWriter>? = nil,
         configuration: HTTPClientConfiguration = .init(),

--- a/Sources/HTTPClient/HTTPClient.swift
+++ b/Sources/HTTPClient/HTTPClient.swift
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP API Proposal open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift HTTP API Proposal project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// We are using an exported import here since we don't want developers
+// to have to import both this module and the HTTPAPIs module.
+@_exported public import HTTPAPIs
+
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+public var httpClient: some HTTPClient {
+    #if canImport(Darwin)
+    HTTPClientURLSession.shared
+    #else
+    UnsupportedPlatformHTTPClient()
+    #endif
+}

--- a/Sources/HTTPClient/URLSession/HTTPTypeConversionError.swift
+++ b/Sources/HTTPClient/URLSession/HTTPTypeConversionError.swift
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP API Proposal open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift HTTP API Proposal project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+enum HTTPTypeConversionError: Error {
+    case failedToConvertHTTPTypesToURLType
+    case failedToConvertURLTypeToHTTPTypes
+}
+
+#endif

--- a/Sources/HTTPClient/URLSession/TLSVersion+tls_protocol_version_t.swift
+++ b/Sources/HTTPClient/URLSession/TLSVersion+tls_protocol_version_t.swift
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP API Proposal open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift HTTP API Proposal project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+import NetworkTypes
+import Security
+
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+extension TLSVersion {
+    var tlsProtocolVersion: tls_protocol_version_t? {
+        switch self {
+        case .v1_2:
+            .TLSv12
+        case .v1_3:
+            .TLSv13
+        default:
+            nil
+        }
+    }
+}
+#endif

--- a/Sources/HTTPClient/URLSession/URLSessionHTTPClient.swift
+++ b/Sources/HTTPClient/URLSession/URLSessionHTTPClient.swift
@@ -1,0 +1,113 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP API Proposal open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift HTTP API Proposal project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+import HTTPAPIs
+import Foundation
+import HTTPTypesFoundation
+import NetworkTypes
+import Synchronization
+
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+final class HTTPClientURLSession: HTTPClient, Sendable {
+    static let shared = HTTPClientURLSession()
+
+    typealias RequestWriter = URLSessionRequestStreamBridge
+    typealias ResponseReader = URLSessionTaskDelegateBridge
+
+    struct SessionConfiguration: Hashable {
+        var minimumTLSVersion: TLSVersion
+        var maximumTLSVersion: TLSVersion
+
+        init(_ configuration: HTTPClientConfiguration) {
+            self.minimumTLSVersion = configuration.security.minimumTLSVersion
+            self.maximumTLSVersion = configuration.security.maximumTLSVersion
+        }
+
+        var configuration: URLSessionConfiguration {
+            let configuration = URLSessionConfiguration.default
+            configuration.usesClassicLoadingMode = false
+            if let version = self.minimumTLSVersion.tlsProtocolVersion {
+                configuration.tlsMinimumSupportedProtocolVersion = version
+            }
+            if let version = self.maximumTLSVersion.tlsProtocolVersion {
+                configuration.tlsMaximumSupportedProtocolVersion = version
+            }
+            return configuration
+        }
+    }
+
+    // TODO: Do we need to remove sessions again to avoid holding onto the memory forever
+    let sessions: Mutex<[SessionConfiguration: URLSession]> = .init([:])
+
+    func session(for configuration: HTTPClientConfiguration) -> URLSession {
+        let sessionConfiguration = SessionConfiguration(configuration)
+        return self.sessions.withLock {
+            if let session = $0[sessionConfiguration] {
+                return session
+            }
+            let session = URLSession(configuration: sessionConfiguration.configuration)
+            $0[sessionConfiguration] = session
+            return session
+        }
+    }
+
+    func request(for request: HTTPRequest, configuration: HTTPClientConfiguration) throws -> URLRequest {
+        guard var request = URLRequest(httpRequest: request) else {
+            throw HTTPTypeConversionError.failedToConvertHTTPTypesToURLType
+        }
+        request.allowsExpensiveNetworkAccess = configuration.path.allowsExpensiveNetworkAccess
+        request.allowsConstrainedNetworkAccess = configuration.path.allowsConstrainedNetworkAccess
+        return request
+    }
+
+    func perform<Return>(
+        request: HTTPRequest,
+        body: consuming HTTPClientRequestBody<RequestWriter>?,
+        configuration: HTTPClientConfiguration,
+        eventHandler: borrowing some HTTPClientEventHandler & ~Escapable & ~Copyable,
+        responseHandler: (HTTPResponse, consuming ResponseReader) async throws -> Return
+    ) async throws -> Return {
+        let request = try self.request(for: request, configuration: configuration)
+        let session = self.session(for: configuration)
+        let task: URLSessionTask
+        let delegateBridge: URLSessionTaskDelegateBridge
+        if let body {
+            task = session.uploadTask(withStreamedRequest: request)
+            delegateBridge = URLSessionTaskDelegateBridge(body: body)
+        } else {
+            task = session.dataTask(with: request)
+            delegateBridge = URLSessionTaskDelegateBridge(body: nil)
+        }
+        task.delegate = delegateBridge
+        task.resume()
+        return try await withTaskCancellationHandler {
+            let result: Result<Return, any Error>
+            do {
+                let response = try await delegateBridge.processDelegateCallbacksBeforeResponse(eventHandler)
+                guard let response = (response as? HTTPURLResponse)?.httpResponse else {
+                    throw HTTPTypeConversionError.failedToConvertURLTypeToHTTPTypes
+                }
+                result = .success(try await responseHandler(response, delegateBridge))
+            } catch {
+                result = .failure(error)
+            }
+            try await delegateBridge.processDelegateCallbacksAfterResponse(eventHandler)
+            return try result.get()
+        } onCancel: {
+            task.cancel()
+        }
+    }
+}
+#endif

--- a/Sources/HTTPClient/URLSession/URLSessionRequestStreamBridge.swift
+++ b/Sources/HTTPClient/URLSession/URLSessionRequestStreamBridge.swift
@@ -1,0 +1,139 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP API Proposal open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift HTTP API Proposal project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+import HTTPAPIs
+import BasicContainers
+import Foundation
+
+// TODO: Can we get rid of this actor
+@globalActor actor RequestBodyActor: GlobalActor {
+    static let shared = RequestBodyActor()
+}
+
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@RequestBodyActor
+final class URLSessionRequestStreamBridge: NSObject, StreamDelegate, @unchecked Sendable {
+    let inputStream: InputStream
+    private let outputStream: OutputStream
+    private var spaceContinuation: CheckedContinuation<Void, Never>?
+    private var outputStreamOpened: Bool = false
+    var writeFailed: Bool = false
+
+    override init() {
+        var inputStream: InputStream? = nil
+        var outputStream: OutputStream? = nil
+        unsafe Stream.getBoundStreams(
+            withBufferSize: 128 * 1024,
+            inputStream: &inputStream,
+            outputStream: &outputStream
+        )
+        self.inputStream = inputStream!
+        self.outputStream = outputStream!
+
+        super.init()
+    }
+
+    func write(_ span: Span<UInt8>) async throws {
+        if !self.outputStreamOpened {
+            self.outputStreamOpened = true
+            unsafe self.outputStream.delegate = self
+            CFWriteStreamSetDispatchQueue(
+                self.outputStream as CFWriteStream,
+                DispatchQueue(label: "HTTPClientRequestBody")
+            )
+            self.outputStream.open()
+        }
+        var remaining = span
+        while !remaining.isEmpty {
+            try Task.checkCancellation()
+            await self.waitForSpace()
+            let written = unsafe remaining.withUnsafeBufferPointer { buffer in
+                unsafe self.outputStream.write(buffer.baseAddress!, maxLength: buffer.count)
+            }
+            if written < 0 {
+                self.writeFailed = true
+                throw self.outputStream.streamError ?? CancellationError()
+            }
+            remaining = remaining.extracting(droppingFirst: written)
+        }
+    }
+
+    private func waitForSpace() async {
+        if self.outputStream.hasSpaceAvailable {
+            return
+        }
+        while !self.outputStream.hasSpaceAvailable {
+            // TODO: This is not handling cancellation appropriately
+            await withCheckedContinuation { continuation in
+                self.spaceContinuation = continuation
+            }
+        }
+    }
+
+    func close() {
+        self.outputStream.close()
+    }
+
+    func stream(_ aStream: Stream, handle eventCode: Stream.Event) {
+        if eventCode.contains(.hasSpaceAvailable) {
+            // TODO: Can we get rid of this task and instead use one task group
+            // for the entire client
+            Task.immediate {
+                let continuation = self.spaceContinuation
+                self.spaceContinuation = nil
+                continuation?.resume()
+            }
+        }
+    }
+}
+
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+extension URLSessionRequestStreamBridge: ConcludingAsyncWriter {
+    func produceAndConclude<Return>(
+        body:
+            nonisolated(nonsending) (consuming sending URLSessionRequestStreamBridge) async throws -> (Return, HTTPFields?)
+    ) async throws -> Return {
+        let result: Result<Return, any Error>
+        do {
+            result = .success(try await body(self).0)
+        } catch {
+            result = .failure(error)
+        }
+        await self.close()
+        return try result.get()
+    }
+}
+
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+extension URLSessionRequestStreamBridge: AsyncWriter {
+    func write<Result, Failure: Error>(
+        _ body: nonisolated(nonsending) (inout OutputSpan<UInt8>) async throws(Failure) -> Result
+    ) async throws(EitherError<any Error, Failure>) -> Result {
+        // TODO: Either this needs to be inline or configurable
+        var array = RigidArray<UInt8>(capacity: 1024)
+        do {
+            let result = try await array.append(count: 1024) { outputSpan in
+                try await body(&outputSpan)
+            }
+            try await self.write(array.span)
+            return result
+        } catch let error as Failure {
+            throw .second(error)
+        } catch {
+            throw .first(error)
+        }
+    }
+}
+#endif

--- a/Sources/HTTPClient/URLSession/URLSessionTaskDelegateBridge+ConcludingAsyncReader.swift
+++ b/Sources/HTTPClient/URLSession/URLSessionTaskDelegateBridge+ConcludingAsyncReader.swift
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP API Proposal open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift HTTP API Proposal project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+import HTTPAPIs
+import Foundation
+
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+extension URLSessionTaskDelegateBridge: ConcludingAsyncReader {
+    func consumeAndConclude<Return, Failure: Error>(
+        body: nonisolated(nonsending) (consuming sending URLSessionTaskDelegateBridge) async throws(Failure) -> Return
+    ) async throws(Failure) -> (Return, HTTPFields?) {
+        try await (body(self), nil)
+    }
+}
+
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+extension URLSessionTaskDelegateBridge: AsyncReader {
+    func read<Return, Failure: Error>(
+        maximumCount: Int?,
+        body: nonisolated(nonsending) (consuming Span<UInt8>) async throws(Failure) -> Return
+    ) async throws(EitherError<any Error, Failure>) -> Return {
+        let data: Data?
+        do {
+            data = try await self.data(maximumCount: maximumCount)
+        } catch {
+            throw .first(error)
+        }
+        guard let data else {
+            do {
+                return try await body(InlineArray<0, UInt8>.zero().span)
+            } catch {
+                throw .second(error)
+            }
+        }
+        do {
+            return try await body(data.span)
+        } catch {
+            throw .second(error)
+        }
+    }
+}
+#endif

--- a/Sources/HTTPClient/URLSession/URLSessionTaskDelegateBridge.swift
+++ b/Sources/HTTPClient/URLSession/URLSessionTaskDelegateBridge.swift
@@ -1,0 +1,415 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP API Proposal open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift HTTP API Proposal project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+import HTTPAPIs
+import Foundation
+import HTTPTypesFoundation
+import Synchronization
+
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+final class URLSessionTaskDelegateBridge: NSObject, Sendable, URLSessionDataDelegate {
+    private enum Callback: Sendable {
+        case response(URLResponse)
+        case redirection(
+            response: HTTPURLResponse,
+            newRequest: URLRequest,
+            completionHandler: @Sendable (URLRequest?) -> Void
+        )
+        case challenge(
+            challenge: URLAuthenticationChallenge,
+            completionHandler: @Sendable (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+        )
+        case error(any Error)
+    }
+    // TODO: This stream need to respect backpressure
+    private let stream: AsyncStream<Callback>
+    private let continuation: AsyncStream<Callback>.Continuation
+    private let requestBody: HTTPClientRequestBody<URLSessionRequestStreamBridge>?
+    // TODO: Can we get rid of this task and instead use on task group per client?
+    @RequestBodyActor
+    private var requestBodyTask: Task<Void, Never>? = nil
+
+    init(body: consuming HTTPClientRequestBody<URLSessionRequestStreamBridge>?) {
+        var continuation: AsyncStream<Callback>.Continuation?
+        self.stream = AsyncStream { continuation = $0 }
+        self.continuation = continuation!
+        self.requestBody = body
+    }
+
+    // MARK: - Data path
+
+    enum State {
+        case awaitingResponse
+        case awaitingData(CheckedContinuation<Data?, any Error>)
+        case awaitingConsumption(Data, complete: Bool, error: (any Error)?, suspendedTask: URLSessionTask?)
+    }
+
+    let state: Mutex<State> = .init(.awaitingResponse)
+
+    func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+    ) {
+        let oldState = self.state.withLock { state in
+            defer {
+                switch state {
+                case .awaitingResponse:
+                    state = .awaitingConsumption(Data(), complete: false, error: nil, suspendedTask: nil)
+                case .awaitingData, .awaitingConsumption:
+                    break
+                }
+            }
+            return state
+        }
+        switch oldState {
+        case .awaitingResponse:
+            self.continuation.yield(.response(response))
+        case .awaitingData, .awaitingConsumption:
+            break
+        }
+        completionHandler(.allow)
+    }
+
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        let oldState = self.state.withLock { state in
+            defer {
+                switch state {
+                case .awaitingData:
+                    state = .awaitingConsumption(Data(), complete: false, error: nil, suspendedTask: nil)
+                case .awaitingResponse:
+                    state = .awaitingConsumption(Data(), complete: true, error: nil, suspendedTask: nil)
+                case .awaitingConsumption(let existingData, let complete, let error, var suspendedTask):
+                    let newData = existingData + data
+                    if newData.count > 256 * 1024 && suspendedTask == nil {
+                        dataTask.suspend()
+                        suspendedTask = dataTask
+                    }
+                    state = .awaitingConsumption(
+                        newData,
+                        complete: complete,
+                        error: error,
+                        suspendedTask: suspendedTask
+                    )
+                }
+            }
+            return state
+        }
+        switch oldState {
+        case .awaitingData(let continuation):
+            continuation.resume(returning: data)
+        case .awaitingResponse:
+            // We don't support data before response
+            self.continuation.yield(.error(URLError(.unknown)))
+            dataTask.cancel()
+        case .awaitingConsumption:
+            break
+        }
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: (any Error)?) {
+        let oldState = self.state.withLock { state in
+            defer {
+                switch state {
+                case .awaitingResponse, .awaitingData:
+                    state = .awaitingConsumption(Data(), complete: true, error: nil, suspendedTask: nil)
+                case .awaitingConsumption(let existingData, _, let error, _):
+                    state = .awaitingConsumption(existingData, complete: true, error: error, suspendedTask: nil)
+                }
+            }
+            return state
+        }
+        switch oldState {
+        case .awaitingResponse:
+            // We don't support completion before response
+            self.continuation.yield(.error(error ?? URLError(.unknown)))
+        case .awaitingData(let continuation):
+            if let error = error {
+                continuation.resume(throwing: error)
+            } else {
+                continuation.resume(returning: nil)
+            }
+        case .awaitingConsumption:
+            break
+        }
+        self.continuation.finish()
+    }
+
+    func data(maximumCount: Int?) async throws -> Data? {
+        // TODO: This continuation is not supporting cancellation
+        try await withCheckedThrowingContinuation { continuation in
+            let oldState = self.state.withLock { state in
+                defer {
+                    switch state {
+                    case .awaitingConsumption(let existingData, let complete, let error, _):
+                        if !existingData.isEmpty || complete {
+                            let remainingData =
+                                if let maximumCount, existingData.count > maximumCount {
+                                    existingData[maximumCount...]
+                                } else {
+                                    Data()
+                                }
+                            state = .awaitingConsumption(
+                                remainingData,
+                                complete: complete,
+                                error: existingData.isEmpty ? nil : error,
+                                suspendedTask: nil
+                            )
+                        } else {
+                            state = .awaitingData(continuation)
+                        }
+                    case .awaitingResponse:
+                        fatalError("Unexpected state")
+                    case .awaitingData:
+                        fatalError("Must not read concurrently")
+                    }
+                }
+                return state
+            }
+            switch oldState {
+            case .awaitingConsumption(let existingData, let complete, let error, let suspendedTask):
+                if !existingData.isEmpty {
+                    let data =
+                        if let maximumCount, existingData.count > maximumCount {
+                            existingData[..<maximumCount]
+                        } else {
+                            existingData
+                        }
+                    continuation.resume(returning: data)
+                    suspendedTask?.resume()
+                } else if complete {
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume(returning: nil)
+                    }
+                }
+            case .awaitingResponse, .awaitingData:
+                break
+            }
+        }
+    }
+
+    // MARK: - Request body
+
+    override func responds(to aSelector: Selector) -> Bool {
+        if aSelector == #selector(
+            (any URLSessionTaskDelegate).urlSession(_:task:needNewBodyStreamFrom:completionHandler:)
+        ) {
+            switch self.requestBody {
+            case nil:
+                return false
+            case .restartable:
+                return false
+            case .seekable:
+                return true
+            }
+        }
+        return super.responds(to: aSelector)
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        needNewBodyStream completionHandler: @escaping @Sendable (InputStream?) -> Void
+    ) {
+        Task.immediate { @RequestBodyActor in
+            self.requestBodyTask?.cancel()
+            switch self.requestBody {
+            case nil:
+                fatalError()
+            case .restartable(let producer):
+                self.requestBodyTask = Task.immediate { @RequestBodyActor in
+                    let bridge = URLSessionRequestStreamBridge()
+                    completionHandler(bridge.inputStream)
+                    do {
+                        try await producer(bridge)
+                    } catch {
+                        if bridge.writeFailed {
+                            // Ignore error
+                        } else {
+                            self.requestBodyStreamFailed(with: error)
+                        }
+                    }
+                }
+            case .seekable(let producer):
+                self.requestBodyTask = Task.immediate { @RequestBodyActor in
+                    let bridge = URLSessionRequestStreamBridge()
+                    completionHandler(bridge.inputStream)
+                    do {
+                        try await producer(0, bridge)
+                    } catch {
+                        if bridge.writeFailed {
+                            // Ignore error
+                        } else {
+                            self.requestBodyStreamFailed(with: error)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        needNewBodyStreamFrom offset: Int64,
+        completionHandler: @escaping @Sendable (InputStream?) -> Void
+    ) {
+        Task.immediate { @RequestBodyActor in
+            self.requestBodyTask?.cancel()
+            switch self.requestBody {
+            case nil:
+                fatalError()
+            case .restartable:
+                fatalError()
+            case .seekable(let producer):
+                self.requestBodyTask = Task.immediate { @RequestBodyActor in
+                    let bridge = URLSessionRequestStreamBridge()
+                    completionHandler(bridge.inputStream)
+                    do {
+                        try await producer(offset, bridge)
+                    } catch {
+                        if bridge.writeFailed {
+                            // Ignore error
+                        } else {
+                            self.requestBodyStreamFailed(with: error)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Events
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping @Sendable (URLRequest?) -> Void
+    ) {
+        guard let scheme = request.url?.scheme?.lowercased(),
+            scheme == "https" || scheme == "http"
+        else {
+            completionHandler(nil)
+            return
+        }
+        if case .enqueued = self.continuation.yield(
+            .redirection(response: response, newRequest: request, completionHandler: completionHandler)
+        ) {
+        } else {
+            completionHandler(nil)
+        }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping @Sendable (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        if case .enqueued = self.continuation.yield(
+            .challenge(challenge: challenge, completionHandler: completionHandler)
+        ) {
+        } else {
+            completionHandler(.performDefaultHandling, nil)
+        }
+    }
+
+    func requestBodyStreamFailed(with error: any Error) {
+        self.continuation.yield(.error(error))
+    }
+
+    func processDelegateCallbacksBeforeResponse(
+        _ eventHandler: borrowing some HTTPClientEventHandler & ~Escapable & ~Copyable
+    ) async throws -> URLResponse {
+        for await callback in self.stream {
+            switch callback {
+            case .response(let response):
+                return response
+            case .redirection(let response, let request, let completionHandler):
+                do {
+                    guard let httpResponse = response.httpResponse,
+                        let httpRequest = request.httpRequest
+                    else {
+                        completionHandler(nil)
+                        throw HTTPTypeConversionError.failedToConvertURLTypeToHTTPTypes
+                    }
+                    switch try await eventHandler.handleRedirection(response: httpResponse, newRequest: httpRequest) {
+                    case .follow(let finalRequest):
+                        guard let urlRequest = URLRequest(httpRequest: finalRequest) else {
+                            completionHandler(nil)
+                            throw HTTPTypeConversionError.failedToConvertHTTPTypesToURLType
+                        }
+                        completionHandler(urlRequest)
+                    case .deliverRedirectionResponse:
+                        completionHandler(nil)
+                    }
+                } catch is HTTPClientEventHandlerDefaultImplementationError {
+                    completionHandler(request)
+                } catch {
+                    completionHandler(nil)
+                    throw error
+                }
+            case .challenge(let challenge, let completionHandler):
+                do {
+                    if let trust = challenge.protectionSpace.serverTrust {
+                        switch try await eventHandler.handleServerTrust(trust) {
+                        case .default:
+                            completionHandler(.performDefaultHandling, nil)
+                        case .allow:
+                            completionHandler(.useCredential, URLCredential(trust: trust))
+                        case .deny:
+                            completionHandler(.cancelAuthenticationChallenge, nil)
+                        }
+                    } else {
+                        completionHandler(.performDefaultHandling, nil)
+                    }
+                } catch is HTTPClientEventHandlerDefaultImplementationError {
+                    completionHandler(.performDefaultHandling, nil)
+                } catch {
+                    completionHandler(.cancelAuthenticationChallenge, nil)
+                    throw error
+                }
+            case .error(let error):
+                throw error
+            }
+        }
+        fatalError()
+    }
+
+    func processDelegateCallbacksAfterResponse(
+        _ eventHandler: borrowing some HTTPClientEventHandler & ~Escapable & ~Copyable
+    ) async throws {
+        for await callback in self.stream {
+            switch callback {
+            case .response:
+                break
+            case .redirection(_, _, let completionHandler):
+                completionHandler(nil)
+            case .challenge(_, let completionHandler):
+                completionHandler(.cancelAuthenticationChallenge, nil)
+            case .error(let error):
+                await self.requestBodyTask?.value
+                throw error
+            }
+        }
+        await self.requestBodyTask?.value
+    }
+}
+#endif

--- a/Sources/HTTPClient/UnspportedPlatform/UnsupportedPlatformHTTPClient.swift
+++ b/Sources/HTTPClient/UnspportedPlatform/UnsupportedPlatformHTTPClient.swift
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP API Proposal open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift HTTP API Proposal project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import HTTPAPIs
+
+/// This struct implements an HTTP client that is used on unsupported platforms and will result in a runtime
+/// fatal error.
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+struct UnsupportedPlatformHTTPClient: HTTPClient {
+    struct ConcludingWriter: ConcludingAsyncWriter {
+        struct Writer: AsyncWriter {
+            func write<Result, Failure>(
+                _ body: (inout OutputSpan<UInt8>) async throws(Failure) -> Result
+            ) async throws(EitherError<Never, Failure>) -> Result {
+                fatalError("Unspported platform")
+            }
+        }
+
+        func produceAndConclude<Return>(
+            body: (consuming sending Writer) async throws -> (Return, HTTPFields?)
+        ) async throws -> Return {
+            fatalError("Unspported platform")
+        }
+    }
+    struct ConcludingReader: ConcludingAsyncReader {
+        struct Reader: AsyncReader {
+            func read<Return, Failure>(
+                maximumCount: Int?,
+                body: (consuming Span<UInt8>) async throws(Failure) -> Return
+            ) async throws(EitherError<Never, Failure>) -> Return {
+                fatalError("Unspported platform")
+            }
+        }
+
+        func consumeAndConclude<Return, Failure>(
+            body: (consuming sending Reader) async throws(Failure) -> Return
+        ) async throws(Failure) -> (Return, HTTPFields?) where Failure: Error {
+            fatalError("Unspported platform")
+        }
+    }
+
+    func perform<Return>(
+        request: HTTPRequest,
+        body: consuming HTTPClientRequestBody<ConcludingWriter>?,
+        configuration: HTTPClientConfiguration,
+        eventHandler: borrowing some HTTPClientEventHandler & ~Copyable & ~Escapable,
+        responseHandler: (HTTPResponse, consuming ConcludingReader) async throws -> Return
+    ) async throws -> Return {
+        fatalError("Unspported platform")
+    }
+}

--- a/Tests/HTTPClientTests/HTTPClientTests.swift
+++ b/Tests/HTTPClientTests/HTTPClientTests.swift
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP API Proposal open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift HTTP API Proposal project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import HTTPClient
+import Testing
+
+let testsEnabled: Bool = {
+    #if canImport(Darwin)
+    true
+    #else
+    false
+    #endif
+}()
+
+@Suite
+struct HTTPClientTests {
+    @Test(.enabled(if: testsEnabled))
+    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    func testHTTPBin() async throws {
+        let request = HTTPRequest(
+            method: .get,
+            scheme: "https",
+            authority: "httpbin.org",
+            path: "/get"
+        )
+        try await httpClient.perform(
+            request: request,
+            body: nil
+        ) { response, responseBodyAndTrailers in
+            #expect(response.status == .ok)
+            let (_, trailers) = try await responseBodyAndTrailers.collect(upTo: 1024) { span in
+                let isEmpty = span.isEmpty
+                #expect(!isEmpty)
+            }
+            #expect(trailers == nil)
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new `HTTClient` target that offers a platform default HTTP client. To back this on Darwin platforms we are using `URLSession`.
