### PR TITLE
Add `Middleware` module and associated tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -61,6 +61,10 @@ let package = Package(
             ],
             swiftSettings: extraSettings
         ),
+        .target(
+            name: "Middleware",
+            swiftSettings: extraSettings
+        ),
 
         // MARK: Tests
         .testTarget(
@@ -81,6 +85,13 @@ let package = Package(
             name: "HTTPClientTests",
             dependencies: [
                 "HTTPClient"
+            ],
+            swiftSettings: extraSettings
+        ),
+        .testTarget(
+            name: "MiddlewareTests",
+            dependencies: [
+                "Middleware"
             ],
             swiftSettings: extraSettings
         ),

--- a/Sources/Middleware/ChainedMiddleware.swift
+++ b/Sources/Middleware/ChainedMiddleware.swift
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP API Proposal open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift HTTP API Proposal project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// A middleware implementation that links two middleware chains together.
+///
+/// ``ChainedMiddleware`` is responsible for properly composing two middleware chains
+/// so that the output from the first middleware becomes the input to the second.
+/// This allows for building complex processing pipelines through composition.
+///
+/// This type is primarily used internally by the ``MiddlewareChainBuilder`` to combine
+/// middleware components in a type-safe way.
+struct ChainedMiddleware<First: Middleware, Second: Middleware>: Middleware where First.NextInput == Second.Input {
+    /// The first middleware in the chain.
+    private let first: First
+
+    /// The second middleware in the chain, which receives output from the first middleware.
+    private let second: Second
+
+    init(
+        first: First,
+        second: Second
+    ) {
+        self.first = first
+        self.second = second
+    }
+
+    /// Processes input through both middlewares in sequence.
+    ///
+    /// This method implements the core chaining behavior by passing the input through
+    /// the first middleware, then using the output of that operation as the input to
+    /// the second middleware.
+    ///
+    /// - Parameters:
+    ///   - input: The initial input value to pass to the first middleware.
+    ///   - next: The next handler function to call after both middlewares have processed the input.
+    ///
+    /// - Throws: Any error that occurs during processing in either middleware.
+    func intercept(
+        input: consuming First.Input,
+        next: (consuming Second.NextInput) async throws -> Void
+    ) async throws {
+        try await first.intercept(input: input) { middleInput in
+            try await second.intercept(input: middleInput, next: next)
+        }
+    }
+}

--- a/Sources/Middleware/Middleware.swift
+++ b/Sources/Middleware/Middleware.swift
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP API Proposal open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift HTTP API Proposal project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// A protocol that defines middleware components for processing inputs and passing them to the next stage.
+///
+/// The `Middleware` protocol provides a way to intercept inputs of type `Input`,
+/// process them, and then optionally transform them into `NextInput` before passing
+/// to the next middleware.
+///
+/// Middlewares can be composed to form processing pipelines where each middleware
+/// performs a specific operation like authentication, logging, caching, etc.
+///
+/// - Note: Middleware components are designed to be composable. You can use the
+///   `MiddlewareChainBuilder` to easily construct middleware chains.
+public protocol Middleware<Input, NextInput>: Sendable {
+    /// The input type that this middleware accepts.
+    associatedtype Input: ~Copyable
+
+    /// The type passed to the next middleware in the chain.
+    /// Defaults to the same type as `Input` if not specified.
+    associatedtype NextInput: ~Copyable = Input
+
+    /// Intercepts and processes the input, then calls the next middleware or handler.
+    ///
+    /// This method defines the core behavior of a middleware. It receives the current input,
+    /// performs its operation, and then passes control to the next middleware or handler.
+    ///
+    /// - Parameters:
+    ///   - input: The input data to be processed by this middleware.
+    ///   - next: A closure representing the next step in the middleware chain.
+    ///           It accepts a parameter of type `NextInput`.
+    ///
+    /// - Throws: Any error that occurs during processing.
+    func intercept(
+        input: consuming Input,
+        next: (consuming NextInput) async throws -> Void
+    ) async throws
+}

--- a/Sources/Middleware/MiddlewareBuilder.swift
+++ b/Sources/Middleware/MiddlewareBuilder.swift
@@ -1,0 +1,79 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP API Proposal open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift HTTP API Proposal project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// A result builder that enables a declarative syntax for constructing middleware chains.
+///
+/// ``MiddlewareBuilder`` leverages Swift's result builder feature to allow developers
+/// to create complex middleware pipelines using a clean, DSL-like syntax. It handles
+/// the type checking and composition of middleware components automatically.
+///
+/// This makes it easier to construct middleware chains that might involve multiple
+/// transformations and conditional processing logic without having to manually manage
+/// the type relationships between different middleware components.
+///
+/// Example usage:
+/// ```swift
+/// @MiddlewareBuilder
+/// func buildMiddlewareChain() -> some Middleware<Request, Response> {
+///     LoggingMiddleware()
+///     AuthenticationMiddleware()
+///     if shouldCompress {
+///         CompressionMiddleware()
+///     }
+///     RoutingMiddleware()
+/// }
+/// ```
+@resultBuilder
+public struct MiddlewareBuilder {
+    /// Builds a middleware chain from a single middleware component.
+    ///
+    /// This is the base case for the result builder pattern, handling a single middleware.
+    ///
+    /// - Parameter middleware: The single middleware component to wrap in a chain.
+    /// - Returns: A middleware chain containing the single component.
+    public static func buildPartialBlock<M: Middleware>(
+        first middleware: M
+    ) -> M {
+        middleware
+    }
+
+    /// Chains together two middleware components, ensuring their input and output types match.
+    ///
+    /// This method composes two middlewares where the output of the first matches the input of the second,
+    /// creating a unified processing pipeline.
+    ///
+    /// - Parameters:
+    ///   - accumulated: The first middleware in the chain.
+    ///   - next: The second middleware in the chain, which accepts the output of the first.
+    /// - Returns: A new middleware chain that represents the composition of both middlewares.
+    public static func buildPartialBlock<Input: ~Copyable, MiddleInput: ~Copyable, NextInput: ~Copyable>(
+        accumulated: some Middleware<Input, MiddleInput>,
+        next: some Middleware<MiddleInput, NextInput>
+    ) -> some Middleware<Input, NextInput> {
+        let chained = ChainedMiddleware(first: accumulated, second: next)
+        return ClosureMiddleware(middlewareFunc: chained.intercept)
+    }
+
+    /// Converts a middleware expression to a middleware chain.
+    ///
+    /// This method allows middleware components to be used directly in result builder expressions.
+    ///
+    /// - Parameter middleware: The middleware component to convert.
+    /// - Returns: A middleware chain wrapping the input middleware.
+    public static func buildExpression<M: Middleware>(
+        _ middleware: M
+    ) -> M {
+        middleware
+    }
+}

--- a/Sources/Middleware/MiddlewareChain.swift
+++ b/Sources/Middleware/MiddlewareChain.swift
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP API Proposal open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift HTTP API Proposal project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// A concrete implementation of ``Middleware`` that is backed by a closure.
+struct ClosureMiddleware<Input: ~Copyable, NextInput: ~Copyable>: Middleware {
+    private let middlewareFunc:
+        @Sendable (
+            consuming Input,
+            (consuming NextInput) async throws -> Void
+        ) async throws -> Void
+
+    /// Creates a middleware using a closure.es.
+    ///
+    /// - Parameter middlewareFunc: A closure that implements the middleware's behavior.
+    init(
+        middlewareFunc:
+            @Sendable @escaping (
+                consuming Input,
+                (consuming NextInput) async throws -> Void
+            ) async throws -> Void
+    ) {
+        self.middlewareFunc = middlewareFunc
+    }
+
+    /// Intercepts and processes the input, then calls the next middleware or handler.
+    ///
+    /// This method defines the core behavior of a middleware. It receives the current input,
+    /// performs its operation, and then passes control to the next middleware or handler.
+    ///
+    /// - Parameters:
+    ///   - input: The input data to be processed by this middleware.
+    ///   - next: A closure representing the next step in the middleware chain.
+    ///           It accepts a parameter of type `NextInput`.
+    ///
+    /// - Throws: Any error that occurs during processing.
+    func intercept(
+        input: consuming Input,
+        next: (consuming NextInput) async throws -> Void
+    ) async throws {
+        try await middlewareFunc(input, next)
+    }
+}

--- a/Tests/MiddlewareTests/MiddlewareBuilderTests.swift
+++ b/Tests/MiddlewareTests/MiddlewareBuilderTests.swift
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP API Proposal open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift HTTP API Proposal project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Middleware
+import Testing
+
+private struct ForwardingMiddleware<Input>: Middleware {
+    func intercept(
+        input: consuming Input,
+        next: (consuming Input) async throws -> Void
+    ) async throws {
+        try await next(input)
+    }
+}
+
+private struct TransformingMiddleware<Input, NextInput>: Middleware {
+    private let transformation: @Sendable (Input) async throws -> NextInput
+
+    init(transformation: @escaping @Sendable (Input) async throws -> NextInput) {
+        self.transformation = transformation
+    }
+
+    func intercept(
+        input: consuming Input,
+        next: (consuming NextInput) async throws -> Void
+    ) async throws {
+        try await next(self.transformation(input))
+    }
+}
+
+@Suite
+struct MiddlewareBuilderTests {
+    @Test
+    func forwarding() async throws {
+        let middleware = buildMiddleware {
+            ForwardingMiddleware<Int>()
+        }
+
+        try await middleware.intercept(input: 1) { result in
+            #expect(result == 1)
+        }
+    }
+
+    @Test
+    func forwardingAndTransforming() async throws {
+        let middleware = buildMiddleware {
+            ForwardingMiddleware<Int>()
+            TransformingMiddleware<Int, String> { "\($0 * 2)" }
+            TransformingMiddleware<String, Int> { Int($0)! }
+        }
+
+        try await middleware.intercept(input: 1) { result in
+            #expect(result == 2)
+        }
+    }
+
+    private func buildMiddleware(
+        @MiddlewareBuilder
+        middlewareBuilder: () -> some Middleware<Int, Int>
+    ) -> some Middleware<Int, Int> {
+        middlewareBuilder()
+    }
+}


### PR DESCRIPTION
A common use-case for HTTP client and servers is to put additional middleware's around them. Either outside of the client or inside the server. This is used to share common logic such as logging, tracing or authentication.
