### PR TITLE
Add examples for an echo and proxy HTTP server

### DIFF
--- a/Examples/EchoServer/EchoServer.swift
+++ b/Examples/EchoServer/EchoServer.swift
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP API Proposal open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift HTTP API Proposal project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import HTTPAPIs
+
+/// This examples shows an HTTP echo server.
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@main
+struct EchoServer {
+    static func main() async throws {
+        // TODO: Call echo once we have a concrete server implementation
+        fatalError("Waiting for a concrete HTTP server implementation")
+    }
+
+    static func echo<Server: HTTPServer>(server: Server) async throws {
+        try await server.serve { request, requestContext, requestBodyAndTrailers, responseSender in
+            // Needed since we are lacking call-once closures
+            var requestBodyAndTrailers = Optional(requestBodyAndTrailers)
+            let responseBodyAndTrailers = try await responseSender.send(.init(status: .ok))
+
+            try await responseBodyAndTrailers.produceAndConclude { responseBody in
+                // Needed since we are lacking call-once closures
+                var responseBody = responseBody
+                return try await requestBodyAndTrailers.take()!.consumeAndConclude { reader in
+                    try await responseBody.write(reader)
+                }
+            }
+        }
+    }
+}

--- a/Examples/ProxyServer/ProxyServer.swift
+++ b/Examples/ProxyServer/ProxyServer.swift
@@ -1,0 +1,64 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP API Proposal open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift HTTP API Proposal project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import HTTPAPIs
+import Synchronization
+
+/// This examples shows an HTTP proxy server.
+///
+/// Every incoming request is proxied via an HTTP client. This supports full bi-directional streaming
+/// and trailers.
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@main
+struct ProxyServer {
+    static func main() async throws {
+        // TODO: Call proxy once we have a concrete server implementation
+        fatalError("Waiting for a concrete HTTP server implementation")
+    }
+
+    static func proxy(server: some HTTPServer, client: some HTTPClient & Sendable) async throws {
+        try await server.serve { request, requestContext, serverRequestBodyAndTrailers, responseSender in
+            // We need to use a mutex here to move the requestBodyAndTrailers into the
+            // @Sendable restartable body
+            let serverRequestBodyAndTrailers = Mutex(Optional(serverRequestBodyAndTrailers))
+            // Needed since we are lacking call-once closures
+            var responseSender = Optional(responseSender)
+
+            try await client.perform(
+                request: request,
+                body: .restartable { clientRequestBody in
+                    var clientRequestBody = clientRequestBody
+                    // This takes the request body out of the mutex. Any restarts would hit
+                    // a force-unwrap.
+                    let serverRequestBodyAndTrailers = serverRequestBodyAndTrailers.withLock { $0.take()! }
+
+                    return try await serverRequestBodyAndTrailers.consumeAndConclude { serverRequestBody in
+                        try await clientRequestBody.write(serverRequestBody)
+                    }.1
+                }
+            ) { response, clientResponseBodyAndTrailers in
+                // Needed since we are lacking call-once closures
+                var clientResponseBodyAndTrailers = Optional(clientResponseBodyAndTrailers)
+
+                let serverResponseBodyAndTrailers = try await responseSender.take()!.send(response)
+                try await serverResponseBodyAndTrailers.produceAndConclude { serverResponseBody in
+                    var serverResponseBody = serverResponseBody
+                    return try await clientResponseBodyAndTrailers.take()!.consumeAndConclude { clientResponseBody in
+                        try await serverResponseBody.write(clientResponseBody)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -46,6 +46,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-configuration", from: "1.0.0"),
     ],
     targets: [
+        // MARK: Libraries
         .target(
             name: "HTTPAPIs",
             dependencies: [
@@ -162,6 +163,24 @@ let package = Package(
             dependencies: [
                 "Middleware"
             ],
+            swiftSettings: extraSettings
+        ),
+
+        // MARK: Examples
+        .executableTarget(
+            name: "EchoServer",
+            dependencies: [
+                "HTTPAPIs"
+            ],
+            path: "Examples/EchoServer",
+            swiftSettings: extraSettings
+        ),
+        .executableTarget(
+            name: "ProxyServer",
+            dependencies: [
+                "HTTPAPIs"
+            ],
+            path: "Examples/ProxyServer",
             swiftSettings: extraSettings
         ),
     ]

--- a/Tests/HTTPAPIsTests/EchoTests.swift
+++ b/Tests/HTTPAPIsTests/EchoTests.swift
@@ -29,8 +29,7 @@ extension TestClientAndServer {
                 // Needed since we are lacking call-once closures
                 var responseBody = responseBody
                 return try await requestBodyAndTrailers.take()!.consumeAndConclude { reader in
-                    var reader: RequestConcludingReader.Underlying? = consume reader
-                    try await responseBody.write(reader.take()!)
+                    try await responseBody.write(reader)
                 }
             }
         }


### PR DESCRIPTION
To showcase how the new APIs are working this PR adds an example for an echo and proxy HTTP server. Right now the examples are not runnable because we are lacking a concrete HTTP server implementation but it shows this working on top of the protocols.

The proxy case is interesting since it shows how nicely the reader and writer APIs fit into each other.
