### PR TITLE
Make HTTPClientRequestBody an extensible struct

### DIFF
--- a/Sources/HTTPAPIs/Client/HTTPClientRequestBody.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClientRequestBody.swift
@@ -48,7 +48,7 @@ import AsyncStreaming
 /// }
 /// ```
 @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
-public struct HTTPClientRequestBody<Writer>: Sendable, ~Copyable
+public struct HTTPClientRequestBody<Writer>: Sendable
 where Writer: ConcludingAsyncWriter & ~Copyable, Writer.Underlying.WriteElement == UInt8, Writer.FinalElement == HTTPFields?, Writer: SendableMetatype
 {
     /// The body can be asked to restart writing from an arbitrary offset.
@@ -100,7 +100,7 @@ where Writer: ConcludingAsyncWriter & ~Copyable, Writer.Underlying.WriteElement 
     ///   - inputs: Inputs into the body creation closure.
     ///   - writer: The destination into which to write the body.
     /// - Throws: An error thrown from the body closure.
-    public mutating func write(inputs: Inputs, writer: consuming Writer) async throws {
+    public func write(inputs: Inputs, writer: consuming Writer) async throws {
         try await writeBody(inputs, writer)
     }
 }


### PR DESCRIPTION
### Motivation

The enum form of `HTTPClientRequestBody` wasn't extensible, didn't allow attaching the known body length, and wouldn't allow us to add more properties in the future.

### Modifications

Proposed a struct version of the request body that retains all the information about whether the body is restartable and seekable, so concrete client implementations can check for it and provide better errors, but also gained property to propagate the known length (for example, when uploading a file with a known size), and wraps the `offset` in another struct to again allow adding more similar inputs without breaking API.

This makes the body type more extensible and flexible, but I also retained the existing convenience methods for seekable and restartable with their reduced set of inputs.

I haven't updated the URLSession-based client yet, I'll do that if there's support for this design.

### Result

A more future-proof wrapper for the request body creation closure.

### Test Plan

N/A for now, opening to start a discussion.
