### PR TITLE
Move the default implementation of the client event handlers to the protocol

### DIFF
--- a/Sources/HTTPAPIs/Client/DefaultHTTPClientEventHandler.swift
+++ b/Sources/HTTPAPIs/Client/DefaultHTTPClientEventHandler.swift
@@ -12,27 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Security)
-public import Security
-#endif
-
 @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
-public struct DefaultHTTPClientEventHandler: ~Copyable {
-    public init() {}
-}
-
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
-extension DefaultHTTPClientEventHandler: HTTPClientEventHandler {
-    public func handleRedirection(
-        response: HTTPResponse,
-        newRequest: HTTPRequest
-    ) async throws -> HTTPClientRedirectionAction {
-        .follow(newRequest)
-    }
-
-    #if canImport(Security)
-    public func handleServerTrust(_ trust: SecTrust) async throws -> HTTPClientTrustResult {
-        .default
-    }
-    #endif
+@usableFromInline
+struct DefaultHTTPClientEventHandler: HTTPClientEventHandler, ~Copyable {
+    @usableFromInline
+    init() {}
 }

--- a/Sources/HTTPAPIs/Client/HTTPClientEventHandler.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClientEventHandler.swift
@@ -59,3 +59,19 @@ public protocol HTTPClientEventHandler: ~Escapable, ~Copyable {
     func handleServerTrust(_ trust: SecTrust) async throws -> HTTPClientTrustResult
     #endif
 }
+
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+extension HTTPClientEventHandler where Self: ~Escapable, Self: ~Copyable {
+    public func handleRedirection(
+        response: HTTPResponse,
+        newRequest: HTTPRequest
+    ) async throws -> HTTPClientRedirectionAction {
+        .follow(newRequest)
+    }
+
+    #if canImport(Security)
+    public func handleServerTrust(_ trust: SecTrust) async throws -> HTTPClientTrustResult {
+        .default
+    }
+    #endif
+}


### PR DESCRIPTION
### Motivation

All methods of `HTTPClientEventHandler` should have a default implementation. This allows the conformers to only implement events that they care about, and also allows us to add new events without breaking existing conformers.

### Modifications

Move the extension from `DefaultHTTPClientEventHandler` to `HTTPClientEventHandler`, make `DefaultHTTPClientEventHandler` usable from inline since it's only used as a default argument on the convenience methods.

### Result

Conformers to `HTTPClientEventHandler` no longer need to implement all methods.