### PR TITLE
Add a convenience method for client perform with event handler closures

### DIFF
--- a/Sources/HTTPAPIs/Client/DefaultHTTPClientEventHandler.swift
+++ b/Sources/HTTPAPIs/Client/DefaultHTTPClientEventHandler.swift
@@ -22,24 +22,17 @@ public struct DefaultHTTPClientEventHandler: ~Copyable {
 }
 
 @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
-// TODO: Evaluate if this type should be public and if the default implementations
-// should really throw an error
-public struct HTTPClientEventHandlerDefaultImplementationError: Error {
-    public init() {}
-}
-
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
 extension DefaultHTTPClientEventHandler: HTTPClientEventHandler {
     public func handleRedirection(
         response: HTTPResponse,
         newRequest: HTTPRequest
     ) async throws -> HTTPClientRedirectionAction {
-        throw HTTPClientEventHandlerDefaultImplementationError()
+        .follow(newRequest)
     }
 
     #if canImport(Security)
     public func handleServerTrust(_ trust: SecTrust) async throws -> HTTPClientTrustResult {
-        throw HTTPClientEventHandlerDefaultImplementationError()
+        .default
     }
     #endif
 }

--- a/Sources/HTTPAPIs/Client/HTTPClient.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClient.swift
@@ -93,10 +93,12 @@ extension HTTPClient {
         eventHandler: consuming some HTTPClientEventHandler & ~Escapable & ~Copyable =
             DefaultHTTPClientEventHandler(),
         responseHandler: (HTTPResponse, consuming ResponseConcludingReader) async throws -> Return,
-        onRedirection: @escaping (_ response: HTTPResponse, _ newRequest: HTTPRequest) async throws ->
-            HTTPClientRedirectionAction = { _, _ in throw HTTPClientEventHandlerDefaultImplementationError() },
-        onServerTrust: @escaping (_ trust: SecTrust) async throws -> HTTPClientTrustResult = { _ in
-            throw HTTPClientEventHandlerDefaultImplementationError()
+        onRedirection: (
+            (_ response: HTTPResponse, _ newRequest: HTTPRequest) async throws ->
+                HTTPClientRedirectionAction
+        )? = { .follow($1) },
+        onServerTrust: ((_ trust: SecTrust) async throws -> HTTPClientTrustResult)? = { _ in
+            .default
         },
     ) async throws -> Return {
         // Since the element is ~Copyable but we don't have call-once closures
@@ -144,8 +146,10 @@ extension HTTPClient {
         eventHandler: consuming some HTTPClientEventHandler & ~Escapable & ~Copyable =
             DefaultHTTPClientEventHandler(),
         responseHandler: (HTTPResponse, consuming ResponseConcludingReader) async throws -> Return,
-        onRedirection: @escaping (_ response: HTTPResponse, _ newRequest: HTTPRequest) async throws ->
-            HTTPClientRedirectionAction = { _, _ in throw HTTPClientEventHandlerDefaultImplementationError() },
+        onRedirection: (
+            (_ response: HTTPResponse, _ newRequest: HTTPRequest) async throws ->
+                HTTPClientRedirectionAction
+        )? = { .follow($1) },
     ) async throws -> Return {
         // Since the element is ~Copyable but we don't have call-once closures
         // we need to move it into an Optional and then take it out once

--- a/Sources/HTTPClient/URLSession/URLSessionTaskDelegateBridge.swift
+++ b/Sources/HTTPClient/URLSession/URLSessionTaskDelegateBridge.swift
@@ -360,8 +360,6 @@ final class URLSessionTaskDelegateBridge: NSObject, Sendable, URLSessionDataDele
                     case .deliverRedirectionResponse:
                         completionHandler(nil)
                     }
-                } catch is HTTPClientEventHandlerDefaultImplementationError {
-                    completionHandler(request)
                 } catch {
                     completionHandler(nil)
                     throw error
@@ -380,8 +378,6 @@ final class URLSessionTaskDelegateBridge: NSObject, Sendable, URLSessionDataDele
                     } else {
                         completionHandler(.performDefaultHandling, nil)
                     }
-                } catch is HTTPClientEventHandlerDefaultImplementationError {
-                    completionHandler(.performDefaultHandling, nil)
                 } catch {
                     completionHandler(.cancelAuthenticationChallenge, nil)
                     throw error


### PR DESCRIPTION
### Motivation

`HTTPClient.perform` is inconvenient to use.

### Modifications

Add a convenience `perform` method with default arguments and event handler closures.

Currently the closures are `@escaping` like `HTTPServerClosureRequestHandler` due to an issue with `withoutActuallyEscaping`.