### PR TITLE
Remove inapplicable TODO

### DIFF
--- a/Sources/HTTPClient/URLSession/URLSessionTaskDelegateBridge.swift
+++ b/Sources/HTTPClient/URLSession/URLSessionTaskDelegateBridge.swift
@@ -34,7 +34,10 @@ final class URLSessionTaskDelegateBridge: NSObject, Sendable, URLSessionDataDele
         case error(any Error)
     }
     private weak let task: URLSessionTask?
-    // TODO: This stream need to respect backpressure
+
+    /// This stream and the continuation are used for the events such as redirections.
+    /// There is no way to apply back pressure to these events hence this stream doesn't set buffer
+    /// limits.
     private let stream: AsyncStream<Callback>
     private let continuation: AsyncStream<Callback>.Continuation
     private let requestBody: HTTPClientRequestBody<URLSessionRequestStreamBridge>?


### PR DESCRIPTION
It is not possible for the stream to respect back pressure since URLSessionDelegate methods are called by URLSession without a way to delay them (other than blocking the delegate thread which just moves the buffer elsewhere).

For data delivery, we are suspending and resuming the task based on how much data remains to be consumed. But for events we just have to buffer them.