### PR TITLE
Fix build failures on older compilers and format warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,7 @@ let extraSettings: [SwiftSetting] = [
     .enableUpcomingFeature("ExistentialAny"),
     .enableUpcomingFeature("MemberImportVisibility"),
     .enableUpcomingFeature("InternalImportsByDefault"),
+    .enableUpcomingFeature("ImmutableWeakCaptures"),
 ]
 let package = Package(
     name: "HTTPAPIProposal",

--- a/Sources/HTTPClient/URLSession/URLSessionTaskDelegateBridge.swift
+++ b/Sources/HTTPClient/URLSession/URLSessionTaskDelegateBridge.swift
@@ -35,9 +35,9 @@ final class URLSessionTaskDelegateBridge: NSObject, Sendable, URLSessionDataDele
     }
     private weak let task: URLSessionTask?
 
-    /// This stream and the continuation are used for the events such as redirections.
-    /// There is no way to apply back pressure to these events hence this stream doesn't set buffer
-    /// limits.
+    // This stream and the continuation are used for the events such as redirections.
+    // There is no way to apply back pressure to these events hence this stream doesn't set buffer
+    // limits.
     private let stream: AsyncStream<Callback>
     private let continuation: AsyncStream<Callback>.Continuation
     private let requestBody: HTTPClientRequestBody<URLSessionRequestStreamBridge>?


### PR DESCRIPTION
Enable `weak let` support and fix comment