### PR TITLE
Bump availability to 26.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,7 @@ jobs:
       xcode_16_3_enabled: false
       xcode_16_4_enabled: false
       xcode_26_0_enabled: false
+      xcode_26_1_enabled: false
       macos_xcode_build_enabled: false
       ios_xcode_build_enabled: false
       watchos_xcode_build_enabled: false

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,6 @@ let extraSettings: [SwiftSetting] = [
     .enableUpcomingFeature("ExistentialAny"),
     .enableUpcomingFeature("MemberImportVisibility"),
     .enableUpcomingFeature("InternalImportsByDefault"),
-    .enableUpcomingFeature("ImmutableWeakCaptures"),
 ]
 let package = Package(
     name: "HTTPAPIProposal",

--- a/Sources/AsyncStreaming/Internal/InlineArray+convenience.swift
+++ b/Sources/AsyncStreaming/Internal/InlineArray+convenience.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 extension InlineArray where Element: ~Copyable {
     package static func one(value: consuming Element) -> InlineArray<1, Element> {
         return InlineArray<1, Element>(first: value) { _ in fatalError() }

--- a/Sources/AsyncStreaming/Reader/Array+AsyncReader.swift
+++ b/Sources/AsyncStreaming/Reader/Array+AsyncReader.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 extension Array {
     /// Creates an async reader that provides access to the array's elements.
     ///
@@ -41,7 +41,7 @@ extension Array {
 /// This internal reader type wraps an array and delivers its elements through the ``AsyncReader``
 /// protocol. It maintains a current read position and can deliver elements in chunks based on
 /// the requested maximum count.
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 struct ArrayAsyncReader<Element>: AsyncReader {
     typealias ReadElement = Element
     typealias ReadFailure = Never

--- a/Sources/AsyncStreaming/Reader/AsyncReader+collect.swift
+++ b/Sources/AsyncStreaming/Reader/AsyncReader+collect.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 extension AsyncReader where Self: ~Copyable, Self: ~Escapable, ReadElement: Copyable {
     /// Collects elements from the reader up to a specified limit and processes them with a body function.
     ///

--- a/Sources/AsyncStreaming/Reader/AsyncReader+forEach.swift
+++ b/Sources/AsyncStreaming/Reader/AsyncReader+forEach.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 // swift-format-ignore: AmbiguousTrailingClosureOverload
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 extension AsyncReader where Self: ~Copyable, Self: ~Escapable {
     /// Iterates over all elements from the reader, executing the provided body for each span.
     ///

--- a/Sources/AsyncStreaming/Reader/AsyncReader+map.swift
+++ b/Sources/AsyncStreaming/Reader/AsyncReader+map.swift
@@ -14,7 +14,7 @@
 
 import BasicContainers
 
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 extension AsyncReader where Self: ~Copyable, Self: ~Escapable {
     /// Transforms elements read from this reader using the provided transformation function.
     ///
@@ -54,7 +54,7 @@ extension AsyncReader where Self: ~Copyable, Self: ~Escapable {
 /// This internal reader type wraps another async reader and applies a transformation
 /// to each element read from the base reader. The transformation is applied lazily
 /// as elements are read, maintaining the streaming nature of the operation.
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 struct AsyncMapReader<Base: AsyncReader & ~Copyable & ~Escapable, MappedElement: ~Copyable>: AsyncReader, ~Copyable, ~Escapable {
     typealias ReadElement = MappedElement
     typealias ReadFailure = Base.ReadFailure

--- a/Sources/AsyncStreaming/Reader/AsyncReader.swift
+++ b/Sources/AsyncStreaming/Reader/AsyncReader.swift
@@ -16,7 +16,7 @@
 ///
 /// ``AsyncReader`` defines an interface for types that can asynchronously read elements
 /// of a specified type from a source.
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 public protocol AsyncReader<ReadElement, ReadFailure>: ~Copyable, ~Escapable {
     /// The type of elements that can be read by this reader.
     associatedtype ReadElement: ~Copyable
@@ -66,7 +66,7 @@ public protocol AsyncReader<ReadElement, ReadFailure>: ~Copyable, ~Escapable {
 
 }
 
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 extension AsyncReader where Self: ~Copyable, Self: ~Escapable {
     /// Reads elements from the underlying source and processes them with the provided body closure.
     ///
@@ -115,7 +115,7 @@ extension AsyncReader where Self: ~Copyable, Self: ~Escapable {
     }
 }
 
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 extension AsyncReader where ReadElement: Copyable {
     /// Reads elements from this reader into the provided output span.
     ///

--- a/Sources/AsyncStreaming/Reader/ConcludingAsyncReader+collect.swift
+++ b/Sources/AsyncStreaming/Reader/ConcludingAsyncReader+collect.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 extension ConcludingAsyncReader where Self: ~Copyable {
     /// Collects elements from the underlying async reader and returns both the processed result and final element.
     ///

--- a/Sources/AsyncStreaming/Reader/ConcludingAsyncReader.swift
+++ b/Sources/AsyncStreaming/Reader/ConcludingAsyncReader.swift
@@ -18,7 +18,7 @@
 /// provide a conclusive element after all reads are completed. This is particularly useful
 /// for streams that have meaningful completion states beyond just terminating, such as
 /// HTTP responses that include headers after the body is fully read.
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 public protocol ConcludingAsyncReader<Underlying, FinalElement>: ~Copyable, ~Escapable {
     /// The underlying asynchronous reader type that produces elements.
     associatedtype Underlying: AsyncReader, ~Copyable, ~Escapable

--- a/Sources/AsyncStreaming/Writer/AsyncWriter+AsyncReader.swift
+++ b/Sources/AsyncStreaming/Writer/AsyncWriter+AsyncReader.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 extension AsyncWriter where Self: ~Copyable, Self: ~Escapable {
     /// Writes all elements from an async reader to this writer.
     ///

--- a/Sources/AsyncStreaming/Writer/AsyncWriter.swift
+++ b/Sources/AsyncStreaming/Writer/AsyncWriter.swift
@@ -16,7 +16,7 @@
 ///
 /// ``AsyncWriter`` defines an interface for types that can asynchronously write elements
 /// to a destination by providing an output span buffer for efficient batch writing operations.
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 public protocol AsyncWriter<WriteElement, WriteFailure>: ~Copyable, ~Escapable {
     /// The type of elements that can be written by this writer.
     associatedtype WriteElement: ~Copyable
@@ -95,7 +95,7 @@ public struct AsyncWriterWroteShortError: Error {
     public init() {}
 }
 
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 extension AsyncWriter where Self: ~Copyable, Self: ~Escapable {
     /// Writes the provided element to the underlying destination.
     ///

--- a/Sources/AsyncStreaming/Writer/ConcludingAsyncWriter.swift
+++ b/Sources/AsyncStreaming/Writer/ConcludingAsyncWriter.swift
@@ -18,7 +18,7 @@
 /// provide a conclusive element after writing is complete. This is particularly useful
 /// for streams that have meaningful completion states, such as HTTP response that need
 /// to finalize with optional trailers.
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 public protocol ConcludingAsyncWriter<Underlying, FinalElement>: ~Copyable, ~Escapable {
     /// The underlying asynchronous writer type.
     associatedtype Underlying: AsyncWriter, ~Copyable, ~Escapable
@@ -48,7 +48,7 @@ public protocol ConcludingAsyncWriter<Underlying, FinalElement>: ~Copyable, ~Esc
     ) async throws -> Return
 }
 
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 extension ConcludingAsyncWriter where Self: ~Copyable {
     /// Produces a final element using the underlying async writer without returning a separate value.
     ///
@@ -80,7 +80,7 @@ extension ConcludingAsyncWriter where Self: ~Copyable {
     }
 }
 
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 extension ConcludingAsyncWriter where Self: ~Copyable {
     /// Writes a single element to the underlying writer and concludes with a final element.
     ///

--- a/Sources/AsyncStreaming/Writer/RigidArray+AsyncWriter.swift
+++ b/Sources/AsyncStreaming/Writer/RigidArray+AsyncWriter.swift
@@ -18,7 +18,7 @@ public import BasicContainers
 ///
 /// This extension enables `RigidArray` to be used as an asynchronous writer, allowing
 /// elements to be appended through the async writer interface.
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 extension RigidArray: AsyncWriter {
     /// Provides a buffer to write elements into the rigid array.
     ///

--- a/Sources/HTTPAPIs/Client/DefaultHTTPClientEventHandler.swift
+++ b/Sources/HTTPAPIs/Client/DefaultHTTPClientEventHandler.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 @usableFromInline
 struct DefaultHTTPClientEventHandler: HTTPClientEventHandler, ~Copyable {
     @usableFromInline

--- a/Sources/HTTPAPIs/Client/HTTPClient.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClient.swift
@@ -25,7 +25,7 @@ public import Security
 ///
 /// ``HTTPClient`` provides asynchronous request execution with streaming request
 /// and response bodies.
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 public protocol HTTPClient<RequestConcludingWriter, ResponseConcludingReader>: ~Copyable {
     /// The type used to write request body data and trailers.
     // TODO: Check if we should allow ~Escapable readers https://github.com/apple/swift-http-api-proposal/issues/13
@@ -63,7 +63,7 @@ public protocol HTTPClient<RequestConcludingWriter, ResponseConcludingReader>: ~
     ) async throws -> Return
 }
 
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 extension HTTPClient {
     #if canImport(Darwin)
     /// Performs an HTTP request and processes the response.

--- a/Sources/HTTPAPIs/Client/HTTPClientConfiguration.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClientConfiguration.swift
@@ -27,7 +27,7 @@ public import NetworkTypes
 /// configuration.security.minimumTLSVersion = .v1_3
 /// configuration.path.allowsExpensiveNetworkAccess = false
 /// ```
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 public struct HTTPClientConfiguration: Sendable {
     /// A struct that defines security-related configuration options.
     ///

--- a/Sources/HTTPAPIs/Client/HTTPClientEventHandler.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClientEventHandler.swift
@@ -21,7 +21,7 @@ public import Security
 /// ``HTTPClientEventHandler`` allows custom handling of HTTP redirections and server
 /// trust evaluations during client request processing. Conforming types can implement
 /// custom logic for these events to control client behavior.
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 public protocol HTTPClientEventHandler: ~Escapable, ~Copyable {
     /// Handles 3xx redirection responses received by the HTTP client.
     ///
@@ -60,7 +60,7 @@ public protocol HTTPClientEventHandler: ~Escapable, ~Copyable {
     #endif
 }
 
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 extension HTTPClientEventHandler where Self: ~Escapable, Self: ~Copyable {
     public func handleRedirection(
         response: HTTPResponse,

--- a/Sources/HTTPAPIs/Client/HTTPClientRedirectionAction.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClientRedirectionAction.swift
@@ -16,7 +16,7 @@
 ///
 /// ``HTTPClientRedirectionAction`` specifies whether to follow a redirect to a new location
 /// or deliver the original redirect response to the caller.
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 public enum HTTPClientRedirectionAction: Sendable {
     /// Follows the HTTP redirection by performing the new request.
     ///

--- a/Sources/HTTPAPIs/Client/HTTPClientRequestBody.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClientRequestBody.swift
@@ -19,7 +19,7 @@ import AsyncStreaming
 /// ``HTTPClientRequestBody`` provides two strategies for streaming request body data:
 /// restartable bodies that can be replayed from the beginning for retries or redirects,
 /// and seekable bodies that support resuming from a specific byte offset.
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 public enum HTTPClientRequestBody<Writer>: Sendable, ~Copyable
 where Writer: ConcludingAsyncWriter & ~Copyable, Writer.Underlying.WriteElement == UInt8, Writer.FinalElement == HTTPFields?, Writer: SendableMetatype
 {

--- a/Sources/HTTPAPIs/Client/HTTPClientTrustResult.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClientTrustResult.swift
@@ -17,7 +17,7 @@
 ///
 /// ``HTTPClientTrustResult`` specifies whether to use the system's default trust evaluation,
 /// explicitly allow the connection, or explicitly deny it.
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 public enum HTTPClientTrustResult {
     /// Uses the system's default trust evaluation for the server certificate.
     ///

--- a/Sources/HTTPAPIs/Client/ScopedHTTPClientEventHandler.swift
+++ b/Sources/HTTPAPIs/Client/ScopedHTTPClientEventHandler.swift
@@ -18,7 +18,7 @@ import Synchronization
 public import Security
 #endif
 
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 @usableFromInline
 struct ScopedHTTPClientEventHandler<NextHandler: HTTPClientEventHandler & ~Escapable & ~Copyable>:
     HTTPClientEventHandler, ~Escapable, ~Copyable

--- a/Sources/HTTPAPIs/Server/HTTPServer.swift
+++ b/Sources/HTTPAPIs/Server/HTTPServer.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 /// A protocol that defines the interface for an HTTP server.
 ///
 /// ``HTTPServerProtocol`` provides the contract for server implementations that accept

--- a/Sources/HTTPAPIs/Server/HTTPServerClosureRequestHandler.swift
+++ b/Sources/HTTPAPIs/Server/HTTPServerClosureRequestHandler.swift
@@ -37,7 +37,7 @@ public import HTTPTypes
 ///     }
 /// }
 /// ```
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 public struct HTTPServerClosureRequestHandler<
     RequestReader: ConcludingAsyncReader & ~Copyable,
     ResponseWriter: ConcludingAsyncWriter & ~Copyable,
@@ -93,7 +93,7 @@ where
     }
 }
 
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 extension HTTPServer where Self: ~Copyable, Self: ~Escapable {
     /// Starts an HTTP server with a closure-based request handler.
     ///

--- a/Sources/HTTPAPIs/Server/HTTPServerRequestHandler.swift
+++ b/Sources/HTTPAPIs/Server/HTTPServerRequestHandler.swift
@@ -57,7 +57,7 @@ public import HTTPTypes
 ///     }
 /// }
 /// ```
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 public protocol HTTPServerRequestHandler<RequestReader, ResponseWriter>: Sendable {
     /// The type used to read request body data and trailers.
     associatedtype RequestReader: ConcludingAsyncReader, ~Copyable

--- a/Sources/HTTPAPIs/Server/HTTPServerResponseSender.swift
+++ b/Sources/HTTPAPIs/Server/HTTPServerResponseSender.swift
@@ -21,7 +21,7 @@ public import HTTPTypes
 /// more times using ``sendInformational(_:)`` before sending the final response. This design
 /// ensures proper HTTP semantics where exactly one non-informational response is sent, followed
 /// by optional response body streaming and trailers.
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 public struct HTTPResponseSender<ResponseWriter: ConcludingAsyncWriter & ~Copyable>: ~Copyable {
     private let _sendInformational: (HTTPResponse) async throws -> Void
     private let _send: (HTTPResponse) async throws -> ResponseWriter

--- a/Sources/HTTPClient/HTTPClient.swift
+++ b/Sources/HTTPClient/HTTPClient.swift
@@ -18,7 +18,7 @@
 
 /// This is the default shared HTTP client.
 // TODO: Evaluate merging with the HTTPServer module https://github.com/apple/swift-http-api-proposal/issues/14
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 public var httpClient: some HTTPClient {
     #if canImport(Darwin)
     URLSessionHTTPClient.shared

--- a/Sources/HTTPClient/URLSession/HTTPTypeConversionError.swift
+++ b/Sources/HTTPClient/URLSession/HTTPTypeConversionError.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(Darwin)
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 enum HTTPTypeConversionError: Error {
     case failedToConvertHTTPTypesToURLType
     case failedToConvertURLTypeToHTTPTypes

--- a/Sources/HTTPClient/URLSession/TLSVersion+tls_protocol_version_t.swift
+++ b/Sources/HTTPClient/URLSession/TLSVersion+tls_protocol_version_t.swift
@@ -16,7 +16,7 @@
 import NetworkTypes
 import Security
 
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 extension TLSVersion {
     var tlsProtocolVersion: tls_protocol_version_t? {
         switch self {

--- a/Sources/HTTPClient/URLSession/URLSessionHTTPClient.swift
+++ b/Sources/HTTPClient/URLSession/URLSessionHTTPClient.swift
@@ -19,7 +19,7 @@ import HTTPTypesFoundation
 import NetworkTypes
 import Synchronization
 
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 final class URLSessionHTTPClient: HTTPClient, Sendable {
     static let shared = URLSessionHTTPClient()
 

--- a/Sources/HTTPClient/URLSession/URLSessionRequestStreamBridge.swift
+++ b/Sources/HTTPClient/URLSession/URLSessionRequestStreamBridge.swift
@@ -22,7 +22,7 @@ import Foundation
     static let shared = RequestBodyActor()
 }
 
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 @RequestBodyActor
 final class URLSessionRequestStreamBridge: NSObject, StreamDelegate, @unchecked Sendable {
     let inputStream: InputStream
@@ -99,7 +99,7 @@ final class URLSessionRequestStreamBridge: NSObject, StreamDelegate, @unchecked 
     }
 }
 
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 extension URLSessionRequestStreamBridge: ConcludingAsyncWriter {
     func produceAndConclude<Return>(
         body:
@@ -116,7 +116,7 @@ extension URLSessionRequestStreamBridge: ConcludingAsyncWriter {
     }
 }
 
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 extension URLSessionRequestStreamBridge: AsyncWriter {
     func write<Result, Failure: Error>(
         _ body: (inout OutputSpan<UInt8>) async throws(Failure) -> Result

--- a/Sources/HTTPClient/URLSession/URLSessionTaskDelegateBridge+ConcludingAsyncReader.swift
+++ b/Sources/HTTPClient/URLSession/URLSessionTaskDelegateBridge+ConcludingAsyncReader.swift
@@ -16,7 +16,7 @@
 import HTTPAPIs
 import Foundation
 
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 extension URLSessionTaskDelegateBridge: ConcludingAsyncReader {
     func consumeAndConclude<Return, Failure: Error>(
         body: (consuming sending URLSessionTaskDelegateBridge) async throws(Failure) -> Return
@@ -25,7 +25,7 @@ extension URLSessionTaskDelegateBridge: ConcludingAsyncReader {
     }
 }
 
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 extension URLSessionTaskDelegateBridge: AsyncReader {
     func read<Return, Failure: Error>(
         maximumCount: Int?,

--- a/Sources/HTTPClient/URLSession/URLSessionTaskDelegateBridge.swift
+++ b/Sources/HTTPClient/URLSession/URLSessionTaskDelegateBridge.swift
@@ -18,7 +18,7 @@ import Foundation
 import HTTPTypesFoundation
 import Synchronization
 
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 final class URLSessionTaskDelegateBridge: NSObject, Sendable, URLSessionDataDelegate {
     private enum Callback: Sendable {
         case response(URLResponse)

--- a/Sources/HTTPClient/UnsupportedPlatform/UnsupportedPlatformHTTPClient.swift
+++ b/Sources/HTTPClient/UnsupportedPlatform/UnsupportedPlatformHTTPClient.swift
@@ -16,7 +16,7 @@ import HTTPAPIs
 
 /// This struct implements an HTTP client that is used on unsupported platforms and will result in a runtime
 /// fatal error.
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 struct UnsupportedPlatformHTTPClient: HTTPClient {
     struct ConcludingWriter: ConcludingAsyncWriter {
         struct Writer: AsyncWriter {

--- a/Sources/HTTPServer/HTTPServer.swift
+++ b/Sources/HTTPServer/HTTPServer.swift
@@ -18,7 +18,7 @@
 
 /// This is the default HTTP server.
 // TODO: Evaluate merging with the HTTPClient module https://github.com/apple/swift-http-api-proposal/issues/14
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 public var httpServer: some HTTPServer {
     UnsupportedPlatformHTTPServer()
 }

--- a/Sources/HTTPServer/UnsupportedPlatform/UnsupportedPlatformHTTPServer.swift
+++ b/Sources/HTTPServer/UnsupportedPlatform/UnsupportedPlatformHTTPServer.swift
@@ -16,7 +16,7 @@ import HTTPAPIs
 
 /// This struct implements an HTTP client that is used on unsupported platforms and will result in a runtime
 /// fatal error.
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 struct UnsupportedPlatformHTTPServer: HTTPServer {
     struct ConcludingWriter: ConcludingAsyncWriter {
         struct Writer: AsyncWriter {

--- a/Tests/AsyncStreamingTests/Helpers/TestConcludingAsyncReader.swift
+++ b/Tests/AsyncStreamingTests/Helpers/TestConcludingAsyncReader.swift
@@ -14,7 +14,7 @@
 
 import AsyncStreaming
 
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 struct TestConcludingReader: ConcludingAsyncReader {
     struct UnderlyingReader: AsyncReader {
         typealias ReadElement = Int

--- a/Tests/AsyncStreamingTests/Helpers/TestReader.swift
+++ b/Tests/AsyncStreamingTests/Helpers/TestReader.swift
@@ -15,7 +15,7 @@
 import AsyncStreaming
 import BasicContainers
 
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 struct SimpleReader: AsyncReader {
     typealias ReadElement = Int
     typealias ReadFailure = Never

--- a/Tests/AsyncStreamingTests/Reader/Array+AsyncReaderTests.swift
+++ b/Tests/AsyncStreamingTests/Reader/Array+AsyncReaderTests.swift
@@ -18,7 +18,7 @@ import Testing
 @Suite
 struct ArrayAsyncReaderTests {
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func oneSpan() async throws {
         let array = [1, 2, 3].asyncReader()
         var counter = 0
@@ -30,7 +30,7 @@ struct ArrayAsyncReaderTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func multipleSpans() async throws {
         var array = [1, 2, 3].asyncReader()
         var counter = 0

--- a/Tests/AsyncStreamingTests/Reader/AsyncReader+collectTests.swift
+++ b/Tests/AsyncStreamingTests/Reader/AsyncReader+collectTests.swift
@@ -19,7 +19,7 @@ import Testing
 @Suite
 struct AsyncReaderCollectTests {
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func collectAllElements() async {
         var reader = [1, 2, 3, 4, 5].asyncReader()
 
@@ -31,7 +31,7 @@ struct AsyncReaderCollectTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func collectWithExactLimit() async {
         var reader = [1, 2, 3, 4, 5].asyncReader()
 
@@ -43,7 +43,7 @@ struct AsyncReaderCollectTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func collectEmptyReader() async {
         var reader = [Int]().asyncReader()
 
@@ -55,7 +55,7 @@ struct AsyncReaderCollectTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func collectProcessesAllElements() async {
         var reader = [10, 20, 30].asyncReader()
 
@@ -71,7 +71,7 @@ struct AsyncReaderCollectTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func collectIntoOutputSpan() async {
         var reader = [1, 2, 3, 4, 5].asyncReader()
         var buffer = RigidArray<Int>.init(capacity: 5)
@@ -84,7 +84,7 @@ struct AsyncReaderCollectTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func collectWithNeverFailingReader() async {
         var reader = [1, 2, 3].asyncReader()
 

--- a/Tests/AsyncStreamingTests/Reader/AsyncReader+forEachTests.swift
+++ b/Tests/AsyncStreamingTests/Reader/AsyncReader+forEachTests.swift
@@ -18,7 +18,7 @@ import Testing
 @Suite
 struct AsyncReaderForEachTests {
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func forEachIteratesAllSpans() async throws {
         let reader = [1, 2, 3, 4, 5].asyncReader()
         var elementCount = 0
@@ -31,7 +31,7 @@ struct AsyncReaderForEachTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func forEachProcessesElements() async throws {
         let reader = [10, 20, 30].asyncReader()
         var sum = 0
@@ -46,7 +46,7 @@ struct AsyncReaderForEachTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func forEachWithEmptyReader() async throws {
         let reader = [Int]().asyncReader()
         var callCount = 0
@@ -59,7 +59,7 @@ struct AsyncReaderForEachTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func forEachWithThrowingBody() async {
         enum TestError: Error {
             case failed
@@ -78,7 +78,7 @@ struct AsyncReaderForEachTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func forEachWithNeverFailingReader() async {
         enum TestError: Error {
             case failed
@@ -99,7 +99,7 @@ struct AsyncReaderForEachTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func forEachWithAsyncWork() async throws {
         let reader = [1, 2, 3].asyncReader()
         var results: [Int] = []
@@ -115,7 +115,7 @@ struct AsyncReaderForEachTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func forEachMultipleSpans() async {
         var reader = [1, 2, 3, 4, 5, 6].asyncReader()
         var spanCounts: [Int] = []

--- a/Tests/AsyncStreamingTests/Reader/AsyncReader+mapTests.swift
+++ b/Tests/AsyncStreamingTests/Reader/AsyncReader+mapTests.swift
@@ -18,7 +18,7 @@ import Testing
 @Suite
 struct AsyncReaderMapTests {
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func mapTransformsElements() async throws {
         let reader = [1, 2, 3, 4, 5].asyncReader()
         let mappedReader = reader.map { $0 * 2 }
@@ -34,7 +34,7 @@ struct AsyncReaderMapTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func mapWithTypeConversion() async throws {
         let reader = [1, 2, 3].asyncReader()
         let mappedReader = reader.map { String($0) }
@@ -50,7 +50,7 @@ struct AsyncReaderMapTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func mapEmptyReader() async throws {
         let reader = [Int]().asyncReader()
         let mappedReader = reader.map { $0 * 2 }
@@ -64,7 +64,7 @@ struct AsyncReaderMapTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func mapWithAsyncTransformation() async throws {
         let reader = [1, 2, 3].asyncReader()
         let mappedReader = reader.map { value in
@@ -84,7 +84,7 @@ struct AsyncReaderMapTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func mapPreservesChunking() async {
         let reader = [1, 2, 3, 4, 5, 6].asyncReader()
         var mappedReader = reader.map { $0 + 100 }
@@ -105,7 +105,7 @@ struct AsyncReaderMapTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func mapChaining() async throws {
         let reader = [1, 2, 3].asyncReader()
         let mappedReader =

--- a/Tests/AsyncStreamingTests/Reader/AsyncReaderTests.swift
+++ b/Tests/AsyncStreamingTests/Reader/AsyncReaderTests.swift
@@ -19,7 +19,7 @@ import Testing
 @Suite
 struct AsyncReaderTests {
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func readWithMaximumCount() async {
         var reader = SimpleReader(data: [1, 2, 3, 4, 5])
 
@@ -31,7 +31,7 @@ struct AsyncReaderTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func readWithoutMaximumCount() async {
         var reader = SimpleReader(data: [1, 2, 3, 4, 5])
 
@@ -43,7 +43,7 @@ struct AsyncReaderTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func readEmptySpanAtEnd() async {
         var reader = SimpleReader(data: [1, 2, 3])
 
@@ -61,7 +61,7 @@ struct AsyncReaderTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func readMultipleChunks() async {
         var reader = SimpleReader(data: [1, 2, 3, 4, 5, 6])
         var chunks: [[Int]] = []
@@ -80,7 +80,7 @@ struct AsyncReaderTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func readIntoCopyableElements() async {
         var reader = SimpleReader(data: [1, 2, 3, 4, 5])
         var buffer = RigidArray<Int>()

--- a/Tests/AsyncStreamingTests/Reader/ConcludingAsyncReaderTests.swift
+++ b/Tests/AsyncStreamingTests/Reader/ConcludingAsyncReaderTests.swift
@@ -18,7 +18,7 @@ import Testing
 @Suite
 struct ConcludingAsyncReaderTests {
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func consumeAndConcludeReturnsResult() async throws {
         let reader = TestConcludingReader(data: [1, 2, 3, 4, 5])
 
@@ -38,7 +38,7 @@ struct ConcludingAsyncReaderTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func consumeAndConcludeWithEmptyReader() async throws {
         let reader = TestConcludingReader(data: [])
 
@@ -56,7 +56,7 @@ struct ConcludingAsyncReaderTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func collectReturnsResultAndFinal() async {
         let reader = TestConcludingReader(data: [10, 20, 30])
 
@@ -69,7 +69,7 @@ struct ConcludingAsyncReaderTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func collectEmptyConcludingReader() async {
         let reader = TestConcludingReader(data: [])
 
@@ -82,7 +82,7 @@ struct ConcludingAsyncReaderTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func collectProcessesAllElements() async {
         let reader = TestConcludingReader(data: [1, 2, 3, 4])
 

--- a/Tests/AsyncStreamingTests/Writer/AsyncWriter+AsyncReaderTests.swift
+++ b/Tests/AsyncStreamingTests/Writer/AsyncWriter+AsyncReaderTests.swift
@@ -18,7 +18,7 @@ import Testing
 @Suite
 struct AsyncWriterAsyncReaderTests {
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func writeReaderToWriter() async {
         let reader = [1, 2, 3, 4, 5].asyncReader()
         var writer = TestWriter()
@@ -29,7 +29,7 @@ struct AsyncWriterAsyncReaderTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func writeEmptyReaderToWriter() async {
         let reader = [Int]().asyncReader()
         var writer = TestWriter()
@@ -40,7 +40,7 @@ struct AsyncWriterAsyncReaderTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func writeLargeReaderToWriter() async {
         let data = Array(1...100)
         let reader = data.asyncReader()
@@ -52,7 +52,7 @@ struct AsyncWriterAsyncReaderTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func writeReaderStreamingBehavior() async {
         // Create a reader that will produce multiple spans
         struct ChunkedReader: AsyncReader {
@@ -91,7 +91,7 @@ struct AsyncWriterAsyncReaderTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func writeTransformedReaderToWriter() async {
         let reader = [1, 2, 3, 4, 5].asyncReader().map { $0 * 2 }
         var writer = TestWriter()
@@ -102,7 +102,7 @@ struct AsyncWriterAsyncReaderTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func writeMultipleReadersToSameWriter() async {
         let reader1 = [1, 2, 3].asyncReader()
         let reader2 = [4, 5, 6].asyncReader()
@@ -115,7 +115,7 @@ struct AsyncWriterAsyncReaderTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func pipingDataBetweenReaderAndWriter() async {
         // This test simulates a typical use case: reading from one source
         // and writing to another destination

--- a/Tests/AsyncStreamingTests/Writer/AsyncWriterTests.swift
+++ b/Tests/AsyncStreamingTests/Writer/AsyncWriterTests.swift
@@ -19,7 +19,7 @@ import Testing
 @Suite
 struct AsyncWriterTests {
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func writeElement() async {
         var writer = TestWriter()
 
@@ -29,7 +29,7 @@ struct AsyncWriterTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func writeMultipleElements() async {
         var writer = TestWriter()
 
@@ -41,7 +41,7 @@ struct AsyncWriterTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func writeWithOutputSpan() async {
         var writer = TestWriter()
 
@@ -55,7 +55,7 @@ struct AsyncWriterTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func writeSpan() async {
         var writer = TestWriter()
         let data = [1, 2, 3, 4, 5]
@@ -66,7 +66,7 @@ struct AsyncWriterTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func writeEmptySpan() async {
         var writer = TestWriter()
         let data: [Int] = []
@@ -77,7 +77,7 @@ struct AsyncWriterTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func writeLargeSpan() async {
         var writer = TestWriter(capacity: 100)
         let data = Array(1...50)
@@ -88,7 +88,7 @@ struct AsyncWriterTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func writeSpanExceedingCapacity() async {
         var writer = TestWriter(capacity: 5)
         let data = Array(1...10)
@@ -107,7 +107,7 @@ struct AsyncWriterTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func multipleWrites() async {
         var writer = TestWriter()
 

--- a/Tests/AsyncStreamingTests/Writer/ConcludingAsyncWriterTests.swift
+++ b/Tests/AsyncStreamingTests/Writer/ConcludingAsyncWriterTests.swift
@@ -18,7 +18,7 @@ import Testing
 @Suite
 struct ConcludingAsyncWriterTests {
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func produceAndConcludeReturnsResult() async throws {
         let writer = TestConcludingWriter()
 
@@ -34,7 +34,7 @@ struct ConcludingAsyncWriterTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func produceAndConcludeWithFinalElementOnly() async throws {
         let writer = TestConcludingWriter()
 
@@ -49,7 +49,7 @@ struct ConcludingAsyncWriterTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func writeAndConcludeWithSingleElement() async throws {
         let writer = TestConcludingWriter()
 
@@ -59,7 +59,7 @@ struct ConcludingAsyncWriterTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func writeAndConcludeWithSpan() async throws {
         let writer = TestConcludingWriter()
         let data = [1, 2, 3, 4, 5]
@@ -70,7 +70,7 @@ struct ConcludingAsyncWriterTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func writeAndConcludeWithEmptySpan() async throws {
         let writer = TestConcludingWriter()
         let data: [Int] = []
@@ -81,7 +81,7 @@ struct ConcludingAsyncWriterTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func multipleWritesBeforeConclude() async throws {
         let writer = TestConcludingWriter()
 
@@ -105,7 +105,7 @@ struct ConcludingAsyncWriterTests {
     }
 
     @Test
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func produceAndConcludeWithNoWrites() async throws {
         let writer = TestConcludingWriter()
 

--- a/Tests/HTTPClientTests/HTTPClientTests.swift
+++ b/Tests/HTTPClientTests/HTTPClientTests.swift
@@ -26,7 +26,7 @@ let testsEnabled: Bool = {
 @Suite
 struct HTTPClientTests {
     @Test(.enabled(if: testsEnabled))
-    @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func testHTTPBin() async throws {
         let request = HTTPRequest(
             method: .get,


### PR DESCRIPTION
Xcode 26.1 does not support `weak let`, so setting the minimum version to 26.2 and disabling 26.1 on CIs