### PR TITLE
Change HTTPClientRequestBody.produce into ConcludingAsyncWriter.write

### DIFF
--- a/Sources/HTTPClient/URLSession/URLSessionTaskDelegateBridge.swift
+++ b/Sources/HTTPClient/URLSession/URLSessionTaskDelegateBridge.swift
@@ -235,7 +235,7 @@ final class URLSessionTaskDelegateBridge: NSObject, Sendable, URLSessionDataDele
                 let bridge = URLSessionRequestStreamBridge()
                 completionHandler(bridge.inputStream)
                 do {
-                    try await requestBody.produce(into: bridge)
+                    try await bridge.write(requestBody)
                 } catch {
                     if bridge.writeFailed {
                         // Ignore error
@@ -262,7 +262,7 @@ final class URLSessionTaskDelegateBridge: NSObject, Sendable, URLSessionDataDele
                 let bridge = URLSessionRequestStreamBridge()
                 completionHandler(bridge.inputStream)
                 do {
-                    try await requestBody.produce(offset: offset, into: bridge)
+                    try await bridge.write(requestBody, from: offset)
                 } catch {
                     if bridge.writeFailed {
                         // Ignore error


### PR DESCRIPTION
`HTTPClientRequestBody.produce(into:)` sounds weirdly backwards. I think it's more natural to think about writing in terms of the writer, so I'm hoping to flip it into `ConcludingAsyncWriter.write` as an extension.