### PR TITLE
Fix crash with HTTP request cancellation

### DIFF
--- a/Tests/HTTPClientTests/HTTPClientTests.swift
+++ b/Tests/HTTPClientTests/HTTPClientTests.swift
@@ -672,8 +672,7 @@ struct HTTPClientTests {
         }
     }
 
-    // TODO: This test crashes. It can be enabled once we have correctly dealt with task cancellation.
-    @Test(.enabled(if: false), .timeLimit(.minutes(1)))
+    @Test(.enabled(if: testsEnabled), .timeLimit(.minutes(1)))
     @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func cancelPreHeaders() async throws {
         // The /stall HTTP endpoint is not expected to return at all.
@@ -699,8 +698,7 @@ struct HTTPClientTests {
         }
     }
 
-    // TODO: This test crashes. It can be enabled once we have correctly dealt with task cancellation.
-    @Test(.enabled(if: false), .timeLimit(.minutes(1)))
+    @Test(.enabled(if: testsEnabled), .timeLimit(.minutes(1)))
     @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func cancelPreBody() async throws {
         // The /stall_body HTTP endpoint gives headers, but is not expected to return a


### PR DESCRIPTION
This crash occurred when writing a new automated test to validate cancellation of an HTTP request.

It used to be a `fatalError()` to exit the `for` loop in `processDelegateCallbacksBeforeResponse()`, but that is incorrect.

it is actually valid for that to occur if we cancel the task performing the HTTP request. Doing so causes the `AsyncStream` being looped on to return `nil` as its final element and then we exit the loop.

This should be handled correctly by propagating a `CancellationError` upwards.