### PR TITLE
Workaround the compiler and runtime crash

### DIFF
--- a/Sources/AsyncStreaming/Reader/AsyncReader+forEach.swift
+++ b/Sources/AsyncStreaming/Reader/AsyncReader+forEach.swift
@@ -77,6 +77,7 @@ extension AsyncReader where Self: ~Copyable, Self: ~Escapable {
     ///     // Process the chunk
     /// }
     /// ```
+    @inlinable
     public consuming func forEach<Failure: Error>(
         body: (consuming Span<ReadElement>) async throws(Failure) -> Void
     ) async throws(Failure) where ReadFailure == Never {

--- a/Sources/AsyncStreaming/Writer/AsyncWriter.swift
+++ b/Sources/AsyncStreaming/Writer/AsyncWriter.swift
@@ -92,6 +92,7 @@ public protocol AsyncWriter<WriteElement, WriteFailure>: ~Copyable, ~Escapable {
 /// This error is thrown when an async writer signals that it cannot accept any more data
 /// by providing an empty output span, but there are still elements remaining to be written.
 public struct AsyncWriterWroteShortError: Error {
+    private let dummy: (any Sendable)? = nil  // TODO: This is just here to workaround https://github.com/swiftlang/swift/pull/86843
     public init() {}
 }
 

--- a/Tests/AsyncStreamingTests/Reader/AsyncReader+mapTests.swift
+++ b/Tests/AsyncStreamingTests/Reader/AsyncReader+mapTests.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(Darwin) && swift(<6.2)  // Disabled on older compilers on Darwin due to a runtime crash
 import AsyncStreaming
 import Testing
 
@@ -123,3 +124,4 @@ struct AsyncReaderMapTests {
         #expect(results == [12, 14, 16])
     }
 }
+#endif

--- a/Tests/AsyncStreamingTests/Writer/AsyncWriter+AsyncReaderTests.swift
+++ b/Tests/AsyncStreamingTests/Writer/AsyncWriter+AsyncReaderTests.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(Darwin) && swift(<6.2)  // Disabled on older compilers on Darwin due to a runtime crash
 import AsyncStreaming
 import Testing
 
@@ -129,3 +130,4 @@ struct AsyncWriterAsyncReaderTests {
         #expect(writer.storage == sourceData)
     }
 }
+#endif


### PR DESCRIPTION
Works around the crashed that is fixed by https://github.com/swiftlang/swift/pull/86843