### PR TITLE
Use the default configuration with persistent storages for the shared client

### DIFF
--- a/Sources/HTTPClient/URLSession/URLSessionHTTPClient.swift
+++ b/Sources/HTTPClient/URLSession/URLSessionHTTPClient.swift
@@ -74,12 +74,13 @@ final class URLSessionHTTPClient: HTTPClient, IdleTimerEntryProvider, Sendable {
         }
 
         func sessionConfiguration(storage: Sessions.Storage) -> URLSessionConfiguration {
-            let configuration: URLSessionConfiguration = switch storage {
-            case .persistent:
-                .default
-            case .ephemeral(let storageConfiguration):
-                storageConfiguration.copy() as! URLSessionConfiguration
-            }
+            let configuration: URLSessionConfiguration =
+                switch storage {
+                case .persistent:
+                    .default
+                case .ephemeral(let storageConfiguration):
+                    storageConfiguration.copy() as! URLSessionConfiguration
+                }
             configuration.usesClassicLoadingMode = false
             configuration.httpMaximumConnectionsPerHost = poolConfiguration.maximumConcurrentHTTP1ConnectionsPerHost
             if let version = self.minimumTLSVersion.tlsProtocolVersion {


### PR DESCRIPTION
Ephemeral configurations were used for all clients in #85 which was too aggressive. The shared client can still use the global persistent storage.