### PR TITLE
Server should not write response body for HEAD request

### DIFF
--- a/Sources/HTTPClientConformance/TestHTTPServer.swift
+++ b/Sources/HTTPClientConformance/TestHTTPServer.swift
@@ -82,6 +82,10 @@ actor TestHTTPServer {
                 case "/200":
                     // OK
                     let writer = try await responseSender.send(HTTPResponse(status: .ok))
+
+                    // Do not write a response body for a HEAD request
+                    if request.method == .head { break }
+
                     try await writer.writeAndConclude("".utf8.span, finalElement: nil)
                 case "/gzip":
                     // If the client didn't say that they supported this encoding,


### PR DESCRIPTION
The server allowed writing a response for a HEAD request, even though that violates the HTTP spec.

This caused a terminating chunk to be written onto the wire, which Wireshark treated as an “HTTP Continuation” disconnected from any previous request.

The URLSession client was graceful about handling this, although it produced a lot of log spam.

<img width="1285" height="981" alt="Screenshot 2026-02-16 at 12 18 27 PM" src="https://github.com/user-attachments/assets/c56a3104-b49f-4604-928c-1dc460da5452" />