### PR TITLE
Add `Connection: close` response header to Conformance Test Server

### DIFF
--- a/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer.swift
@@ -301,6 +301,12 @@ public struct NIOHTTPServer: HTTPServer {
                                 readerState: readerState
                             ),
                             responseSender: HTTPResponseSender { response in
+                                // TODO: This is a temporary fix that informs clients
+                                // that this server does not support keep-alive. This
+                                // server should be updated to eventually support
+                                // keep-alive.
+                                var response = response
+                                response.headerFields[.connection] = "close"
                                 try await outbound.write(.head(response))
                                 return HTTPResponseConcludingAsyncWriter(
                                     writer: outbound,


### PR DESCRIPTION
The test server does not support `Connection: keep-alive`, but it doesn’t send `Connection: close` to the client either. This can cause flaky behavior when a client tries to reuse a connection that’s being shutdown by the server to send an idempotent request.

The client has no option but to throw an error upwards indicating that the connection was closed. This flaky behavior was seen with repeated runs of the `ok()` test.

Fix this by adding `Connection: close` to all responses from the server. This is a temporary fix: in the future, the server should support connection keep-alive.