### PR TITLE
Make HTTPClient.perform mutating

### DIFF
--- a/Examples/ProxyServer/ProxyServer.swift
+++ b/Examples/ProxyServer/ProxyServer.swift
@@ -35,6 +35,7 @@ struct ProxyServer {
             // Needed since we are lacking call-once closures
             var responseSender = Optional(responseSender)
 
+            var client = client
             try await client.perform(
                 request: request,
                 body: .restartable { clientRequestBody in

--- a/Sources/HTTPAPIs/Client/HTTPClient+Conveniences.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClient+Conveniences.swift
@@ -37,6 +37,9 @@ extension HTTPClient where Self: ~Copyable & ~Escapable {
     /// - Returns: The value returned by the response handler closure.
     ///
     /// - Throws: An error if the request fails or if the response handler throws.
+    #if compiler(<6.3)
+    @_lifetime(&self)
+    #endif
     public mutating func perform<Return: ~Copyable>(
         request: HTTPRequest,
         body: consuming HTTPClientRequestBody<RequestWriter>? = nil,
@@ -61,6 +64,9 @@ extension HTTPClient where Self: ~Copyable & ~Escapable {
     /// - Returns: A tuple containing the HTTP response header and the collected response body data.
     ///
     /// - Throws: An error if the request fails, if the response body exceeds the limit, or if collection fails.
+    #if compiler(<6.3)
+    @_lifetime(&self)
+    #endif
     public mutating func get(
         url: URL,
         headerFields: HTTPFields = [:],
@@ -92,6 +98,9 @@ extension HTTPClient where Self: ~Copyable & ~Escapable {
     /// - Returns: A tuple containing the HTTP response header and the collected response body data.
     ///
     /// - Throws: An error if the request fails, if the response body exceeds the limit, or if collection fails.
+    #if compiler(<6.3)
+    @_lifetime(&self)
+    #endif
     public mutating func post(
         url: URL,
         headerFields: HTTPFields = [:],
@@ -124,6 +133,9 @@ extension HTTPClient where Self: ~Copyable & ~Escapable {
     /// - Returns: A tuple containing the HTTP response header and the collected response body data.
     ///
     /// - Throws: An error if the request fails, if the response body exceeds the limit, or if collection fails.
+    #if compiler(<6.3)
+    @_lifetime(&self)
+    #endif
     public mutating func put(
         url: URL,
         headerFields: HTTPFields = [:],
@@ -156,6 +168,9 @@ extension HTTPClient where Self: ~Copyable & ~Escapable {
     /// - Returns: A tuple containing the HTTP response header and the collected response body data.
     ///
     /// - Throws: An error if the request fails, if the response body exceeds the limit, or if collection fails.
+    #if compiler(<6.3)
+    @_lifetime(&self)
+    #endif
     public mutating func delete(
         url: URL,
         headerFields: HTTPFields = [:],
@@ -188,6 +203,9 @@ extension HTTPClient where Self: ~Copyable & ~Escapable {
     /// - Returns: A tuple containing the HTTP response header and the collected response body data.
     ///
     /// - Throws: An error if the request fails, if the response body exceeds the limit, or if collection fails.
+    #if compiler(<6.3)
+    @_lifetime(&self)
+    #endif
     public mutating func patch(
         url: URL,
         headerFields: HTTPFields = [:],

--- a/Sources/HTTPAPIs/Client/HTTPClient+Conveniences.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClient+Conveniences.swift
@@ -37,7 +37,7 @@ extension HTTPClient where Self: ~Copyable & ~Escapable {
     /// - Returns: The value returned by the response handler closure.
     ///
     /// - Throws: An error if the request fails or if the response handler throws.
-    public func perform<Return: ~Copyable>(
+    public mutating func perform<Return: ~Copyable>(
         request: HTTPRequest,
         body: consuming HTTPClientRequestBody<RequestWriter>? = nil,
         options: RequestOptions? = nil,
@@ -61,7 +61,7 @@ extension HTTPClient where Self: ~Copyable & ~Escapable {
     /// - Returns: A tuple containing the HTTP response header and the collected response body data.
     ///
     /// - Throws: An error if the request fails, if the response body exceeds the limit, or if collection fails.
-    public func get(
+    public mutating func get(
         url: URL,
         headerFields: HTTPFields = [:],
         options: RequestOptions? = nil,
@@ -92,7 +92,7 @@ extension HTTPClient where Self: ~Copyable & ~Escapable {
     /// - Returns: A tuple containing the HTTP response header and the collected response body data.
     ///
     /// - Throws: An error if the request fails, if the response body exceeds the limit, or if collection fails.
-    public func post(
+    public mutating func post(
         url: URL,
         headerFields: HTTPFields = [:],
         bodyData: Data,
@@ -124,7 +124,7 @@ extension HTTPClient where Self: ~Copyable & ~Escapable {
     /// - Returns: A tuple containing the HTTP response header and the collected response body data.
     ///
     /// - Throws: An error if the request fails, if the response body exceeds the limit, or if collection fails.
-    public func put(
+    public mutating func put(
         url: URL,
         headerFields: HTTPFields = [:],
         bodyData: Data,
@@ -156,7 +156,7 @@ extension HTTPClient where Self: ~Copyable & ~Escapable {
     /// - Returns: A tuple containing the HTTP response header and the collected response body data.
     ///
     /// - Throws: An error if the request fails, if the response body exceeds the limit, or if collection fails.
-    public func delete(
+    public mutating func delete(
         url: URL,
         headerFields: HTTPFields = [:],
         bodyData: Data? = nil,
@@ -188,7 +188,7 @@ extension HTTPClient where Self: ~Copyable & ~Escapable {
     /// - Returns: A tuple containing the HTTP response header and the collected response body data.
     ///
     /// - Throws: An error if the request fails, if the response body exceeds the limit, or if collection fails.
-    public func patch(
+    public mutating func patch(
         url: URL,
         headerFields: HTTPFields = [:],
         bodyData: Data,

--- a/Sources/HTTPAPIs/Client/HTTPClient.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClient.swift
@@ -49,6 +49,9 @@ public protocol HTTPClient<RequestOptions>: Sendable, ~Copyable, ~Escapable {
     /// - Returns: The value returned by the response handler closure.
     ///
     /// - Throws: An error if the request fails or if the response handler throws.
+    #if compiler(<6.3)
+    @_lifetime(&self)
+    #endif
     mutating func perform<Return: ~Copyable>(
         request: HTTPRequest,
         body: consuming HTTPClientRequestBody<RequestWriter>?,

--- a/Sources/HTTPAPIs/Client/HTTPClient.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClient.swift
@@ -49,7 +49,7 @@ public protocol HTTPClient<RequestOptions>: Sendable, ~Copyable, ~Escapable {
     /// - Returns: The value returned by the response handler closure.
     ///
     /// - Throws: An error if the request fails or if the response handler throws.
-    func perform<Return: ~Copyable>(
+    mutating func perform<Return: ~Copyable>(
         request: HTTPRequest,
         body: consuming HTTPClientRequestBody<RequestWriter>?,
         options: RequestOptions,

--- a/Sources/HTTPClient/DefaultHTTPClient.swift
+++ b/Sources/HTTPClient/DefaultHTTPClient.swift
@@ -37,7 +37,7 @@ typealias ActualHTTPClient = AsyncHTTPClient.HTTPClient
 /// connections across multiple requests. It supports HTTP/1.1, HTTP/2, and HTTP/3 protocols,
 /// automatically handling connection management, protocol negotiation, and resource cleanup.
 @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
-public struct DefaultHTTPClient: HTTPAPIs.HTTPClient, ~Copyable {
+public final class DefaultHTTPClient: HTTPAPIs.HTTPClient {
     public struct RequestWriter: AsyncWriter, ~Copyable {
         public mutating func write<Result, Failure>(
             _ body: (inout OutputSpan<UInt8>) async throws(Failure) -> Result

--- a/Sources/HTTPClient/HTTP+Conveniences.swift
+++ b/Sources/HTTPClient/HTTP+Conveniences.swift
@@ -38,14 +38,14 @@ extension HTTP {
     ///
     /// - Throws: An error if the request fails or if the response handler throws.
     @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
-    public static func perform<Client: HTTPClient & ~Copyable & ~Escapable, Return: ~Copyable>(
+    public static func perform<Return: ~Copyable>(
         request: HTTPRequest,
-        body: consuming HTTPClientRequestBody<Client.RequestWriter>? = nil,
-        options: Client.RequestOptions? = nil,
-        on client: borrowing Client = DefaultHTTPClient.shared,
-        responseHandler: (HTTPResponse, consuming Client.ResponseConcludingReader) async throws -> Return,
+        body: consuming HTTPClientRequestBody<DefaultHTTPClient.RequestWriter>? = nil,
+        options: HTTPRequestOptions = .init(),
+        on client: DefaultHTTPClient = .shared,
+        responseHandler: (HTTPResponse, consuming DefaultHTTPClient.ResponseConcludingReader) async throws -> Return,
     ) async throws -> Return {
-        return try await client.perform(request: request, body: body, options: options, responseHandler: responseHandler)
+        try await client.perform(request: request, body: body, options: options, responseHandler: responseHandler)
     }
 
     /// Performs an HTTP GET request and collects the response body.
@@ -64,14 +64,15 @@ extension HTTP {
     ///
     /// - Throws: An error if the request fails, if the response body exceeds the limit, or if collection fails.
     @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
-    public static func get<Client: HTTPClient & ~Copyable & ~Escapable>(
+    public static func get(
         url: URL,
         headerFields: HTTPFields = [:],
-        options: Client.RequestOptions? = nil,
-        on client: borrowing Client = DefaultHTTPClient.shared,
+        options: HTTPRequestOptions = .init(),
+        on client: DefaultHTTPClient = .shared,
         collectUpTo limit: Int,
     ) async throws -> (response: HTTPResponse, bodyData: Data) {
-        try await client.get(url: url, headerFields: headerFields, options: options, collectUpTo: limit)
+        var client = client
+        return try await client.get(url: url, headerFields: headerFields, options: options, collectUpTo: limit)
     }
 
     /// Performs an HTTP POST request with a body and collects the response body.
@@ -91,15 +92,16 @@ extension HTTP {
     ///
     /// - Throws: An error if the request fails, if the response body exceeds the limit, or if collection fails.
     @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
-    public static func post<Client: HTTPClient & ~Copyable & ~Escapable>(
+    public static func post(
         url: URL,
         headerFields: HTTPFields = [:],
         bodyData: Data,
-        options: Client.RequestOptions? = nil,
-        on client: borrowing Client = DefaultHTTPClient.shared,
+        options: HTTPRequestOptions = .init(),
+        on client: DefaultHTTPClient = .shared,
         collectUpTo limit: Int,
     ) async throws -> (response: HTTPResponse, bodyData: Data) {
-        try await client.post(url: url, headerFields: headerFields, bodyData: bodyData, options: options, collectUpTo: limit)
+        var client = client
+        return try await client.post(url: url, headerFields: headerFields, bodyData: bodyData, options: options, collectUpTo: limit)
     }
 
     /// Performs an HTTP PUT request with a body and collects the response body.
@@ -119,15 +121,16 @@ extension HTTP {
     ///
     /// - Throws: An error if the request fails, if the response body exceeds the limit, or if collection fails.
     @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
-    public static func put<Client: HTTPClient & ~Copyable & ~Escapable>(
+    public static func put(
         url: URL,
         headerFields: HTTPFields = [:],
         bodyData: Data,
-        options: Client.RequestOptions? = nil,
-        on client: borrowing Client = DefaultHTTPClient.shared,
+        options: HTTPRequestOptions = .init(),
+        on client: DefaultHTTPClient = .shared,
         collectUpTo limit: Int,
     ) async throws -> (response: HTTPResponse, bodyData: Data) {
-        try await client.put(url: url, headerFields: headerFields, bodyData: bodyData, options: options, collectUpTo: limit)
+        var client = client
+        return try await client.put(url: url, headerFields: headerFields, bodyData: bodyData, options: options, collectUpTo: limit)
     }
 
     /// Performs an HTTP DELETE request and collects the response body.
@@ -147,15 +150,16 @@ extension HTTP {
     ///
     /// - Throws: An error if the request fails, if the response body exceeds the limit, or if collection fails.
     @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
-    public static func delete<Client: HTTPClient & ~Copyable & ~Escapable>(
+    public static func delete(
         url: URL,
         headerFields: HTTPFields = [:],
         bodyData: Data? = nil,
-        options: Client.RequestOptions? = nil,
-        on client: borrowing Client = DefaultHTTPClient.shared,
+        options: HTTPRequestOptions = .init(),
+        on client: DefaultHTTPClient = .shared,
         collectUpTo limit: Int,
     ) async throws -> (response: HTTPResponse, bodyData: Data) {
-        try await client.delete(url: url, headerFields: headerFields, bodyData: bodyData, options: options, collectUpTo: limit)
+        var client = client
+        return try await client.delete(url: url, headerFields: headerFields, bodyData: bodyData, options: options, collectUpTo: limit)
     }
 
     /// Performs an HTTP PATCH request with a body and collects the response body.
@@ -175,14 +179,15 @@ extension HTTP {
     ///
     /// - Throws: An error if the request fails, if the response body exceeds the limit, or if collection fails.
     @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
-    public static func patch<Client: HTTPClient & ~Copyable & ~Escapable>(
+    public static func patch(
         url: URL,
         headerFields: HTTPFields = [:],
         bodyData: Data,
-        options: Client.RequestOptions? = nil,
-        on client: borrowing Client = DefaultHTTPClient.shared,
+        options: HTTPRequestOptions = .init(),
+        on client: DefaultHTTPClient = .shared,
         collectUpTo limit: Int,
     ) async throws -> (response: HTTPResponse, bodyData: Data) {
-        try await client.patch(url: url, headerFields: headerFields, bodyData: bodyData, options: options, collectUpTo: limit)
+        var client = client
+        return try await client.patch(url: url, headerFields: headerFields, bodyData: bodyData, options: options, collectUpTo: limit)
     }
 }

--- a/Sources/HTTPClientConformance/HTTPClientConformance.swift
+++ b/Sources/HTTPClientConformance/HTTPClientConformance.swift
@@ -155,7 +155,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testNotHTTP() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let request = HTTPRequest(
             method: .get,
             scheme: "http",
@@ -170,7 +170,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testNoReason() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let request = HTTPRequest(
             method: .get,
             scheme: "http",
@@ -185,7 +185,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testBadHTTPCase() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let request = HTTPRequest(
             method: .get,
             scheme: "http",
@@ -200,7 +200,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func test204WithContentLength() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let request = HTTPRequest(
             method: .get,
             scheme: "http",
@@ -219,7 +219,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func test304WithContentLength() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let request = HTTPRequest(
             method: .get,
             scheme: "http",
@@ -238,7 +238,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testIncompleteBody() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let request = HTTPRequest(
             method: .get,
             scheme: "http",
@@ -261,7 +261,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testConflictingContentLength() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let request = HTTPRequest(
             method: .get,
             scheme: "http",
@@ -284,7 +284,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testNoLengthHint() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let request = HTTPRequest(
             method: .get,
             scheme: "http",
@@ -304,7 +304,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testOk() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let methods = [HTTPRequest.Method.head, .get, .put, .post, .delete]
         for method in methods {
             let request = HTTPRequest(
@@ -327,7 +327,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testEmptyChunkedBody() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let request = HTTPRequest(
             method: .post,
             scheme: "http",
@@ -353,7 +353,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testEchoString() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let request = HTTPRequest(
             method: .post,
             scheme: "http",
@@ -381,7 +381,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testGzip() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let request = HTTPRequest(
             method: .get,
             scheme: "http",
@@ -410,7 +410,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testDeflate() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let request = HTTPRequest(
             method: .get,
             scheme: "http",
@@ -439,7 +439,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testBrotli() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let request = HTTPRequest(
             method: .get,
             scheme: "http",
@@ -468,7 +468,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testIdentity() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let request = HTTPRequest(
             method: .get,
             scheme: "http",
@@ -489,7 +489,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testCustomHeader() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let request = HTTPRequest(
             method: .post,
             scheme: "http",
@@ -517,7 +517,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testBasicRedirect() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let paths = ["/301", "/308"]
 
         for path in paths {
@@ -544,7 +544,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testInfiniteRedirect() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
 
         let request = HTTPRequest(
             method: .get,
@@ -562,7 +562,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testNotFound() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let request = HTTPRequest(
             method: .get,
             scheme: "http",
@@ -582,7 +582,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testStatusOutOfRangeButValid() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let request = HTTPRequest(
             method: .get,
             scheme: "http",
@@ -611,7 +611,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
 
         try await withThrowingTaskGroup { group in
             for _ in 0..<100 {
-                let client = try await clientFactory()
+                var client = try await clientFactory()
                 group.addTask {
                     try await client.perform(
                         request: request,
@@ -635,7 +635,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testEchoInterleave() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let request = HTTPRequest(
             method: .post,
             scheme: "http",
@@ -678,7 +678,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testClientSendsEmptyHeaderValue() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let request = HTTPRequest(
             method: .post,
             scheme: "http",
@@ -711,7 +711,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
             path: "/speak"
         )
 
-        let client = try await clientFactory()
+        var client = try await clientFactory()
 
         let (stream, continuation) = AsyncStream<String>.makeStream()
 
@@ -748,7 +748,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
 
     func testCancelPreHeaders() async throws {
         try await withThrowingTaskGroup { group in
-            let client = try await clientFactory()
+            var client = try await clientFactory()
             let port = self.testServerPort
 
             group.addTask {
@@ -788,7 +788,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
         try await withThrowingTaskGroup { group in
             // Used by the task to notify when the task group should be cancelled
             let (stream, continuation) = AsyncStream<Void>.makeStream()
-            let client = try await clientFactory()
+            var client = try await clientFactory()
             let port = self.testServerPort
 
             group.addTask {
@@ -836,7 +836,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testGetConvenience() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let (response, data) = try await client.get(
             url: URL(string: "http://127.0.0.1:\(testServerPort)/request")!,
             collectUpTo: .max
@@ -848,7 +848,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testPostConvenience() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let (response, data) = try await client.post(
             url: URL(string: "http://127.0.0.1:\(testServerPort)/request")!,
             bodyData: Data("Hello World".utf8),
@@ -861,7 +861,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testEcho1MBBody() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let request = HTTPRequest(
             method: .post,
             scheme: "http",
@@ -888,7 +888,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testUnderRead() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let request = HTTPRequest(
             method: .get,
             scheme: "http",
@@ -909,7 +909,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testDripRead() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let request = HTTPRequest(
             method: .get,
             scheme: "http",
@@ -945,7 +945,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testHeadWithContentLength() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let request = HTTPRequest(
             method: .head,
             scheme: "http",
@@ -965,7 +965,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testServerSendsMultiValueHeader() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let request = HTTPRequest(
             method: .get,
             scheme: "http",
@@ -990,7 +990,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testClientSendsMultiValueHeader() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let request = HTTPRequest(
             method: .get,
             scheme: "http",
@@ -1025,7 +1025,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
 
     func testBasicCookieSetAndUse() async throws {
         // Get a cookie from the server
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let request1 = HTTPRequest(
             method: .get,
             scheme: "http",
@@ -1070,7 +1070,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testETag() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let request = HTTPRequest(
             method: .get,
             scheme: "http",
@@ -1115,7 +1115,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testURLParams() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         var components = URLComponents(string: "http://127.0.0.1:\(testServerPort)/request")!
         components.queryItems = [
             URLQueryItem(name: "foo", value: "bar"),
@@ -1146,7 +1146,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testTrailerRead() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let request = HTTPRequest(
             method: .get,
             scheme: "http",
@@ -1175,7 +1175,7 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     }
 
     func testTrailerWrite() async throws {
-        let client = try await clientFactory()
+        var client = try await clientFactory()
         let request = HTTPRequest(
             method: .post,
             scheme: "http",

--- a/Tests/HTTPAPIsTests/EchoTests.swift
+++ b/Tests/HTTPAPIsTests/EchoTests.swift
@@ -53,7 +53,7 @@ struct HTTPClientAndServerTests {
                 authority: nil,
                 path: nil
             )
-            let client = clientAndServer
+            var client = clientAndServer
             try await client.perform(
                 request: request,
                 body: .restartable { (requestBody: consuming TestClientAndServer.RequestWriter) async throws -> HTTPFields? in


### PR DESCRIPTION
Opening this to start a discussion. Unsure if this is the right change since we needed `var client = client` in quite a few places. Also needed to change all convenience methods for the concrete client on `HTTP` to be concrete since an `inout` argument cannot have a default value.

Resolves #45