### PR TITLE
Fix a single typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ package boundaries.
 
 We're exploring several interconnected pieces:
 
-- **AsyncStreaming** - Modern streaming primitives that integrate with the latest Swift concepts such as `~Copyabe`, `~Escapable` and structured concurrency. Checkout the [module's README](Sources/AsyncStreaming/README.md) for more details.
+- **AsyncStreaming** - Modern streaming primitives that integrate with the latest Swift concepts such as `~Copyable`, `~Escapable` and structured concurrency. Checkout the [module's README](Sources/AsyncStreaming/README.md) for more details.
 - **NetworkTypes** - Basic cross-platform network configuration types.
 - **HTTPAPIs** - Protocol definitions for HTTP clients and servers.
 - **HTTPClient** - A default platform HTTP client.


### PR DESCRIPTION
### Motivation

Fix a typo in readme.

### Modifications

Changed a word `Copyabe` to be `Copyable`

### Result

No code changes.

### Test Plan

No code changes.