### PR TITLE
Remove CONTRIBUTORS.txt line from license headers

### DIFF
--- a/.license_header_template
+++ b/.license_header_template
@@ -1,0 +1,12 @@
+@@===----------------------------------------------------------------------===@@
+@@
+@@ This source file is part of the Swift HTTP API Proposal open source project
+@@
+@@ Copyright (c) YEARS Apple Inc. and the Swift HTTP API Proposal project authors
+@@ Licensed under Apache License v2.0
+@@
+@@ See LICENSE.txt for license information
+@@
+@@ SPDX-License-Identifier: Apache-2.0
+@@
+@@===----------------------------------------------------------------------===@@

--- a/Examples/EchoServer/EchoServer.swift
+++ b/Examples/EchoServer/EchoServer.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Examples/ProxyServer/ProxyServer.swift
+++ b/Examples/ProxyServer/ProxyServer.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/AHCHTTPClient/AHC+HTTPClient.swift
+++ b/Sources/AHCHTTPClient/AHC+HTTPClient.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/AsyncStreaming/EitherError.swift
+++ b/Sources/AsyncStreaming/EitherError.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/AsyncStreaming/Internal/InlineArray+convenience.swift
+++ b/Sources/AsyncStreaming/Internal/InlineArray+convenience.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/AsyncStreaming/Reader/Array+AsyncReader.swift
+++ b/Sources/AsyncStreaming/Reader/Array+AsyncReader.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/AsyncStreaming/Reader/AsyncReader+collect.swift
+++ b/Sources/AsyncStreaming/Reader/AsyncReader+collect.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/AsyncStreaming/Reader/AsyncReader+forEach.swift
+++ b/Sources/AsyncStreaming/Reader/AsyncReader+forEach.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/AsyncStreaming/Reader/AsyncReader+map.swift
+++ b/Sources/AsyncStreaming/Reader/AsyncReader+map.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/AsyncStreaming/Reader/AsyncReader.swift
+++ b/Sources/AsyncStreaming/Reader/AsyncReader.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/AsyncStreaming/Reader/ConcludingAsyncReader+collect.swift
+++ b/Sources/AsyncStreaming/Reader/ConcludingAsyncReader+collect.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/AsyncStreaming/Reader/ConcludingAsyncReader.swift
+++ b/Sources/AsyncStreaming/Reader/ConcludingAsyncReader.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/AsyncStreaming/Writer/AsyncWriter+AsyncReader.swift
+++ b/Sources/AsyncStreaming/Writer/AsyncWriter+AsyncReader.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/AsyncStreaming/Writer/AsyncWriter.swift
+++ b/Sources/AsyncStreaming/Writer/AsyncWriter.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/AsyncStreaming/Writer/ConcludingAsyncWriter.swift
+++ b/Sources/AsyncStreaming/Writer/ConcludingAsyncWriter.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/AsyncStreaming/Writer/RigidArray+AsyncWriter.swift
+++ b/Sources/AsyncStreaming/Writer/RigidArray+AsyncWriter.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPAPIs/Client/HTTPClient+Conveniences.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClient+Conveniences.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPAPIs/Client/HTTPClient.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClient.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPAPIs/Client/HTTPClientCapability+RequestOptions.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClientCapability+RequestOptions.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPAPIs/Client/HTTPClientCapability+TLSVersionSelection.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClientCapability+TLSVersionSelection.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPAPIs/Client/HTTPClientRequestBody+Data.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClientRequestBody+Data.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPAPIs/Client/HTTPClientRequestBody.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClientRequestBody.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPAPIs/HTTP.swift
+++ b/Sources/HTTPAPIs/HTTP.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPAPIs/Server/HTTPRequestContext.swift
+++ b/Sources/HTTPAPIs/Server/HTTPRequestContext.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPAPIs/Server/HTTPServer.swift
+++ b/Sources/HTTPAPIs/Server/HTTPServer.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPAPIs/Server/HTTPServerClosureRequestHandler.swift
+++ b/Sources/HTTPAPIs/Server/HTTPServerClosureRequestHandler.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPAPIs/Server/HTTPServerRequestHandler.swift
+++ b/Sources/HTTPAPIs/Server/HTTPServerRequestHandler.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPAPIs/Server/HTTPServerResponseSender.swift
+++ b/Sources/HTTPAPIs/Server/HTTPServerResponseSender.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPClient/DefaultHTTPClient.swift
+++ b/Sources/HTTPClient/DefaultHTTPClient.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPClient/HTTP+Conveniences.swift
+++ b/Sources/HTTPClient/HTTP+Conveniences.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPClient/HTTPConnectionPoolConfiguration.swift
+++ b/Sources/HTTPClient/HTTPConnectionPoolConfiguration.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPClient/HTTPRequestOptions.swift
+++ b/Sources/HTTPClient/HTTPRequestOptions.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPClientConformance/HTTPClientConformance.swift
+++ b/Sources/HTTPClientConformance/HTTPClientConformance.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/HTTPRequestConcludingAsyncReader.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/HTTPRequestConcludingAsyncReader.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/HTTPRequestContext.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/HTTPRequestContext.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/HTTPResponseConcludingAsyncWriter.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/HTTPResponseConcludingAsyncWriter.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/HTTPResponseSender.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/HTTPResponseSender.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/HTTPServer.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/HTTPServer.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/HTTPServerClosureRequestHandler.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/HTTPServerClosureRequestHandler.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/HTTPServerRequestHandler.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/HTTPServerRequestHandler.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer+ConnectionContext.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer+ConnectionContext.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer+HTTP1_1.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer+HTTP1_1.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer+ListeningAddress.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer+ListeningAddress.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer+SecureUpgrade.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer+SecureUpgrade.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer+SwiftConfiguration.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer+SwiftConfiguration.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServerConfiguration.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServerConfiguration.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/NIOSSL+X509.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/NIOSSL+X509.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/RawHTTPServer.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/RawHTTPServer.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/RequestResponseMiddlewareBox.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/RequestResponseMiddlewareBox.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/SocketAddress.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/SocketAddress.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/TestHTTPServer.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/TestHTTPServer.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/Middleware/ChainedMiddleware.swift
+++ b/Sources/Middleware/ChainedMiddleware.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/Middleware/Middleware.swift
+++ b/Sources/Middleware/Middleware.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/Middleware/MiddlewareBuilder.swift
+++ b/Sources/Middleware/MiddlewareBuilder.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/Middleware/MiddlewareChain.swift
+++ b/Sources/Middleware/MiddlewareChain.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/NetworkTypes/TLSVersion.swift
+++ b/Sources/NetworkTypes/TLSVersion.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/URLSessionHTTPClient/HTTPClientCapability+DeclarativeTLSHandler.swift
+++ b/Sources/URLSessionHTTPClient/HTTPClientCapability+DeclarativeTLSHandler.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/URLSessionHTTPClient/HTTPClientCapability+RedirectionHandler.swift
+++ b/Sources/URLSessionHTTPClient/HTTPClientCapability+RedirectionHandler.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/URLSessionHTTPClient/HTTPClientCapability+TLSSecurityHandler.swift
+++ b/Sources/URLSessionHTTPClient/HTTPClientCapability+TLSSecurityHandler.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/URLSessionHTTPClient/HTTPClientClientCertificateHandler.swift
+++ b/Sources/URLSessionHTTPClient/HTTPClientClientCertificateHandler.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/URLSessionHTTPClient/HTTPClientRedirectionAction.swift
+++ b/Sources/URLSessionHTTPClient/HTTPClientRedirectionAction.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/URLSessionHTTPClient/HTTPClientRedirectionHandler.swift
+++ b/Sources/URLSessionHTTPClient/HTTPClientRedirectionHandler.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/URLSessionHTTPClient/HTTPClientServerTrustHandler.swift
+++ b/Sources/URLSessionHTTPClient/HTTPClientServerTrustHandler.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/URLSessionHTTPClient/HTTPRequest+SchemeSupported.swift
+++ b/Sources/URLSessionHTTPClient/HTTPRequest+SchemeSupported.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/URLSessionHTTPClient/HTTPTypeConversionError.swift
+++ b/Sources/URLSessionHTTPClient/HTTPTypeConversionError.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/URLSessionHTTPClient/IdleTimer.swift
+++ b/Sources/URLSessionHTTPClient/IdleTimer.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/URLSessionHTTPClient/TLSVersion+tls_protocol_version_t.swift
+++ b/Sources/URLSessionHTTPClient/TLSVersion+tls_protocol_version_t.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/URLSessionHTTPClient/TrustEvaluationPolicy.swift
+++ b/Sources/URLSessionHTTPClient/TrustEvaluationPolicy.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/URLSessionHTTPClient/TrustEvaluationResult.swift
+++ b/Sources/URLSessionHTTPClient/TrustEvaluationResult.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/URLSessionHTTPClient/URLSessionConnectionPoolConfiguration.swift
+++ b/Sources/URLSessionHTTPClient/URLSessionConnectionPoolConfiguration.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/URLSessionHTTPClient/URLSessionHTTPClient.swift
+++ b/Sources/URLSessionHTTPClient/URLSessionHTTPClient.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/URLSessionHTTPClient/URLSessionRequestOptions.swift
+++ b/Sources/URLSessionHTTPClient/URLSessionRequestOptions.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/URLSessionHTTPClient/URLSessionRequestStreamBridge.swift
+++ b/Sources/URLSessionHTTPClient/URLSessionRequestStreamBridge.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/URLSessionHTTPClient/URLSessionTaskDelegateBridge+ConcludingAsyncReader.swift
+++ b/Sources/URLSessionHTTPClient/URLSessionTaskDelegateBridge+ConcludingAsyncReader.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/URLSessionHTTPClient/URLSessionTaskDelegateBridge.swift
+++ b/Sources/URLSessionHTTPClient/URLSessionTaskDelegateBridge.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/AsyncHTTPClientConformanceTests/Suite.swift
+++ b/Tests/AsyncHTTPClientConformanceTests/Suite.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/AsyncStreamingTests/Helpers/Array+Span.swift
+++ b/Tests/AsyncStreamingTests/Helpers/Array+Span.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/AsyncStreamingTests/Helpers/TestConcludingAsyncReader.swift
+++ b/Tests/AsyncStreamingTests/Helpers/TestConcludingAsyncReader.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/AsyncStreamingTests/Helpers/TestConcludingAsyncWriter.swift
+++ b/Tests/AsyncStreamingTests/Helpers/TestConcludingAsyncWriter.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/AsyncStreamingTests/Helpers/TestReader.swift
+++ b/Tests/AsyncStreamingTests/Helpers/TestReader.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/AsyncStreamingTests/Helpers/TestWriter.swift
+++ b/Tests/AsyncStreamingTests/Helpers/TestWriter.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/AsyncStreamingTests/Reader/Array+AsyncReaderTests.swift
+++ b/Tests/AsyncStreamingTests/Reader/Array+AsyncReaderTests.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/AsyncStreamingTests/Reader/AsyncReader+collectTests.swift
+++ b/Tests/AsyncStreamingTests/Reader/AsyncReader+collectTests.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/AsyncStreamingTests/Reader/AsyncReader+forEachTests.swift
+++ b/Tests/AsyncStreamingTests/Reader/AsyncReader+forEachTests.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/AsyncStreamingTests/Reader/AsyncReader+mapTests.swift
+++ b/Tests/AsyncStreamingTests/Reader/AsyncReader+mapTests.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/AsyncStreamingTests/Reader/AsyncReaderTests.swift
+++ b/Tests/AsyncStreamingTests/Reader/AsyncReaderTests.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/AsyncStreamingTests/Reader/ConcludingAsyncReaderTests.swift
+++ b/Tests/AsyncStreamingTests/Reader/ConcludingAsyncReaderTests.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/AsyncStreamingTests/Writer/AsyncWriter+AsyncReaderTests.swift
+++ b/Tests/AsyncStreamingTests/Writer/AsyncWriter+AsyncReaderTests.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/AsyncStreamingTests/Writer/AsyncWriterTests.swift
+++ b/Tests/AsyncStreamingTests/Writer/AsyncWriterTests.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/AsyncStreamingTests/Writer/ConcludingAsyncWriterTests.swift
+++ b/Tests/AsyncStreamingTests/Writer/ConcludingAsyncWriterTests.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/HTTPAPIsTests/EchoTests.swift
+++ b/Tests/HTTPAPIsTests/EchoTests.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/HTTPAPIsTests/Helpers/Array+Span.swift
+++ b/Tests/HTTPAPIsTests/Helpers/Array+Span.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/HTTPAPIsTests/Helpers/Disconnected.swift
+++ b/Tests/HTTPAPIsTests/Helpers/Disconnected.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/HTTPAPIsTests/Helpers/HTTPClientAndServerTests.swift
+++ b/Tests/HTTPAPIsTests/Helpers/HTTPClientAndServerTests.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/HTTPAPIsTests/Helpers/MultiProducerSingleConsumerAsyncChannel+AsyncReader+AsyncWriter.swift
+++ b/Tests/HTTPAPIsTests/Helpers/MultiProducerSingleConsumerAsyncChannel+AsyncReader+AsyncWriter.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/HTTPClientTests/DarwinHTTPClientTests.swift
+++ b/Tests/HTTPClientTests/DarwinHTTPClientTests.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/MiddlewareTests/MiddlewareBuilderTests.swift
+++ b/Tests/MiddlewareTests/MiddlewareBuilderTests.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/NetworkTypesTests/TLSVersionTests.swift
+++ b/Tests/NetworkTypesTests/TLSVersionTests.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //


### PR DESCRIPTION
### Motivation

Fixes #59.

The repo does not ship a `CONTRIBUTORS.txt`, but every source file's license header contains:

```
// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors
```

The soundness license-header check enforces this line because the shared workflow at `swiftlang/github-workflows/.github/workflows/scripts/check-license-header.sh` bakes it into the default template. The issue notes that other Swift OSS projects are also moving away from `CONTRIBUTORS.txt`, so it should be dropped from the headers and the CI template.

### Modifications

- Added a project-local `.license_header_template` (without the `CONTRIBUTORS.txt` line). The soundness script honors this file and uses it instead of the default template.
- Removed the `// See CONTRIBUTORS.txt for the list of Swift HTTP API Proposal project authors` line from the header of every `.swift` file under `Sources/`, `Tests/`, and `Examples/` (99 files).

No other bytes in the headers were changed. The soundness workflow invocation was left as-is; `license_header_check_project_name` is unused when a local template exists, but keeping the input avoids a second churn if the template is ever removed.

### Result

The license-header soundness check passes against the project-local template, and every source file's header reflects the reality that there is no `CONTRIBUTORS.txt`.

### Test Plan

Ran the upstream soundness script against the checked-out tree:

```
$ bash check-license-header.sh
** ✅ Found no files with missing license header.
```

(The script is fetched from `swiftlang/github-workflows@main`, which is the same workflow this repo invokes in `.github/workflows/pull_request.yml`.)