### PR TITLE
Disable URLSession request timeout by default

### DIFF
--- a/Sources/URLSessionHTTPClient/URLSessionHTTPClient.swift
+++ b/Sources/URLSessionHTTPClient/URLSessionHTTPClient.swift
@@ -280,6 +280,8 @@ public final class URLSessionHTTPClient: HTTPClient, IdleTimerEntryProvider {
         request.assumesHTTP3Capable = options.assumesHTTP3Capable
         if let stallTimeout = options.stallTimeout {
             request.timeoutInterval = stallTimeout / .seconds(1)
+        } else {
+            request.timeoutInterval = 24 * 60 * 60 // Set to 24h to essentially disable the timeout
         }
 
         // Disable Content-Type sniffing

--- a/Sources/URLSessionHTTPClient/URLSessionHTTPClient.swift
+++ b/Sources/URLSessionHTTPClient/URLSessionHTTPClient.swift
@@ -281,7 +281,7 @@ public final class URLSessionHTTPClient: HTTPClient, IdleTimerEntryProvider {
         if let stallTimeout = options.stallTimeout {
             request.timeoutInterval = stallTimeout / .seconds(1)
         } else {
-            request.timeoutInterval = 24 * 60 * 60 // Set to 24h to essentially disable the timeout
+            request.timeoutInterval = 24 * 60 * 60  // Set to 24h to essentially disable the timeout
         }
 
         // Disable Content-Type sniffing


### PR DESCRIPTION
As discussed, the stall timeout can be implemented through a middleware. The default stall timeout of URLSession should be disabled to match the behavior with AHC and avoid requiring an option to disable it.