### PR TITLE
Update availability to anyAppleOS 26.0

### DIFF
--- a/Examples/EchoServer/EchoServer.swift
+++ b/Examples/EchoServer/EchoServer.swift
@@ -14,7 +14,7 @@
 import HTTPAPIs
 
 /// This examples shows an HTTP echo server.
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 @main
 struct EchoServer {
     static func main() async throws {

--- a/Examples/ExampleMiddleware/ForwardingMiddleware.swift
+++ b/Examples/ExampleMiddleware/ForwardingMiddleware.swift
@@ -25,7 +25,7 @@ public struct ForwardingMiddleware<Input: ~Copyable & ~Escapable>: Middleware {
     }
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension Middleware {
     public func forwarding() -> ForwardingMiddleware<Input> {
         ForwardingMiddleware()

--- a/Examples/ExampleMiddleware/HTTPServerLoggingMiddleware.swift
+++ b/Examples/ExampleMiddleware/HTTPServerLoggingMiddleware.swift
@@ -21,7 +21,7 @@ public import Middleware
 /// decorators that output information about the HTTP request path, method, response status,
 /// and the number of bytes read from the request body and written to the response body.
 /// This middleware is useful for debugging and monitoring HTTP traffic.
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public struct HTTPServerLoggingMiddleware<
     RequestConcludingAsyncReader: ConcludingAsyncReader & ~Copyable,
     ResponseConcludingAsyncWriter: ConcludingAsyncWriter & ~Copyable
@@ -98,7 +98,7 @@ where
     }
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension Middleware where Input: ~Copyable, NextInput: ~Copyable {
     /// Creates logging middleware for HTTP servers.
     ///
@@ -135,7 +135,7 @@ extension Middleware where Input: ~Copyable, NextInput: ~Copyable {
     }
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public struct HTTPRequestLoggingConcludingAsyncReader<
     Base: ConcludingAsyncReader & ~Copyable
 >: ConcludingAsyncReader, ~Copyable
@@ -201,7 +201,7 @@ where
     }
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public struct HTTPResponseLoggingConcludingAsyncWriter<
     Base: ConcludingAsyncWriter & ~Copyable
 >: ConcludingAsyncWriter, ~Copyable

--- a/Examples/ExampleMiddleware/HTTPServerMiddlewareInput.swift
+++ b/Examples/ExampleMiddleware/HTTPServerMiddlewareInput.swift
@@ -19,7 +19,7 @@ public import HTTPAPIs
 /// request body reader, and response sender. This boxing is necessary because some of these
 /// parameters are `~Copyable` types that cannot be stored in tuples, and it provides a
 /// convenient way to pass all request-handling components through the middleware chain.
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public struct HTTPServerMiddlewareInput<
     RequestReader: ConcludingAsyncReader & ~Copyable,
     ResponseWriter: ConcludingAsyncWriter & ~Copyable

--- a/Examples/ExampleMiddleware/HTTPServerRequestHandlerMiddleware.swift
+++ b/Examples/ExampleMiddleware/HTTPServerRequestHandlerMiddleware.swift
@@ -19,7 +19,7 @@ public import Middleware
 /// ``HTTPServerRequestHandlerMiddleware`` serves as an example terminal middleware that reads
 /// the entire request body and writes it back as the response body with a 200 OK status.
 /// This middleware has `Never` as its `NextInput` type, indicating it's the end of the chain.
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public struct HTTPServerRequestHandlerMiddleware<
     RequestConcludingAsyncReader: ConcludingAsyncReader & ~Copyable,
     ResponseConcludingAsyncWriter: ConcludingAsyncWriter & ~Copyable,
@@ -63,7 +63,7 @@ where
     }
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension Middleware where Input: ~Copyable, NextInput: ~Copyable {
     /// Creates a request handler middleware that echoes the request body back as the response.
     ///

--- a/Examples/MiddlewareClient/ExampleMiddlewareClient.swift
+++ b/Examples/MiddlewareClient/ExampleMiddlewareClient.swift
@@ -14,7 +14,7 @@
 import HTTPAPIs
 import Middleware
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 struct ExampleMiddlewareClient<Client: HTTPClient & ~Copyable, ClientMiddleware: Middleware<HTTPRequest, HTTPRequest>>: HTTPClient, ~Copyable {
     typealias RequestOptions = Client.RequestOptions
     typealias RequestWriter = Client.RequestWriter
@@ -56,7 +56,7 @@ struct ExampleMiddlewareClient<Client: HTTPClient & ~Copyable, ClientMiddleware:
     }
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 struct RequestMiddleware<Client: HTTPClient & ~Copyable>: Middleware {
     typealias Input = HTTPRequest
     typealias NextInput = Input

--- a/Examples/MiddlewareClient/MiddlewareClient.swift
+++ b/Examples/MiddlewareClient/MiddlewareClient.swift
@@ -18,7 +18,7 @@ import Logging
 import Middleware
 
 /// This example shows how to use middleware together with an HTTP client.
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 @main
 struct MiddlewareClient {
     static func main() async throws {

--- a/Examples/MiddlewareServer/ExampleMiddlewareServer.swift
+++ b/Examples/MiddlewareServer/ExampleMiddlewareServer.swift
@@ -17,7 +17,7 @@ import Logging
 import Middleware
 
 /// This is an example server that wraps an HTTP server inside a middleware.
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 struct ExampleMiddlewareServer<
     Server: HTTPServer,
     ServerMiddleware: Middleware & Sendable
@@ -62,7 +62,7 @@ where
     }
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 struct RequestMiddleware<Server: HTTPServer>: Middleware
 where
     Server.RequestConcludingReader: ~Copyable,

--- a/Examples/MiddlewareServer/MiddlewareServer.swift
+++ b/Examples/MiddlewareServer/MiddlewareServer.swift
@@ -17,7 +17,7 @@ import Logging
 import Middleware
 
 /// This example shows how to use middleware together with an HTTP server.
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 @main
 struct MiddlewareServer {
     static func main() async throws {

--- a/Examples/ProxyServer/ProxyServer.swift
+++ b/Examples/ProxyServer/ProxyServer.swift
@@ -18,7 +18,7 @@ import Synchronization
 ///
 /// Every incoming request is proxied via an HTTP client. This supports full bi-directional streaming
 /// and trailers.
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 @main
 struct ProxyServer {
     static func main() async throws {

--- a/Sources/AHCHTTPClient/AHC+HTTPClient.swift
+++ b/Sources/AHCHTTPClient/AHC+HTTPClient.swift
@@ -20,7 +20,7 @@ import NIOCore
 import NIOHTTP1
 import Synchronization
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension AsyncHTTPClient.HTTPClient: HTTPAPIs.HTTPClient {
     public typealias RequestWriter = RequestBodyWriter
     public typealias ResponseConcludingReader = ResponseReader

--- a/Sources/FetchHTTPClient/FetchHTTPClient.swift
+++ b/Sources/FetchHTTPClient/FetchHTTPClient.swift
@@ -36,7 +36,6 @@ enum FetchError: Error {
     case TrailersUnsupported
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, *)
 public final class FetchHTTPClient: HTTPAPIs.HTTPClient {
     public typealias RequestWriter = RequestBodyWriter
     public typealias ResponseConcludingReader = ResponseReader

--- a/Sources/HTTPAPIs/AsyncWriter+AsyncReader.swift
+++ b/Sources/HTTPAPIs/AsyncWriter+AsyncReader.swift
@@ -13,7 +13,7 @@
 
 public import AsyncStreaming
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension AsyncWriter where Self: ~Copyable, Self: ~Escapable {
     /// Writes all elements from an async reader to this writer.
     ///
@@ -35,9 +35,6 @@ extension AsyncWriter where Self: ~Copyable, Self: ~Escapable {
     /// // Copy all data from reader to writer
     /// try await fileWriter.write(dataReader)
     /// ```
-    #if compiler(<6.3)
-    @_lifetime(self: copy self)
-    #endif
     public mutating func write<Reader>(
         _ reader: consuming Reader
     ) async throws

--- a/Sources/HTTPAPIs/AsyncWriter.swift
+++ b/Sources/HTTPAPIs/AsyncWriter.swift
@@ -13,7 +13,7 @@
 
 public import AsyncStreaming
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension AsyncWriter where Self: ~Copyable, Self: ~Escapable {
     /// Writes the provided element to the underlying destination.
     ///
@@ -34,9 +34,6 @@ extension AsyncWriter where Self: ~Copyable, Self: ~Escapable {
     /// // Write data to a file asynchronously
     /// try await fileWriter.write(dataChunk)
     /// ```
-    #if compiler(<6.3)
-    @_lifetime(self: copy self)
-    #endif
     public mutating func write(_ element: consuming WriteElement) async throws(WriteFailure) {
         // Since the element is ~Copyable but we don't have call-once closures
         // we need to move it into an Optional and then take it out once. This
@@ -61,9 +58,6 @@ extension AsyncWriter where Self: ~Copyable, Self: ~Escapable {
     /// - Parameter span: The elements to write.
     ///
     /// - Throws: An error of type `WriteFailure` if the write operation cannot be completed successfully.
-    #if compiler(<6.3)
-    @_lifetime(self: copy self)
-    #endif
     public mutating func write(_ span: Span<WriteElement>) async throws(WriteFailure)
     where WriteElement: Copyable {
         do {

--- a/Sources/HTTPAPIs/Client/HTTPClient+Conveniences.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClient+Conveniences.swift
@@ -19,7 +19,7 @@ public import struct Foundation.URL
 public import struct Foundation.Data
 #endif
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension HTTPClient
 where
     Self: ~Copyable & ~Escapable,
@@ -42,9 +42,6 @@ where
     /// - Returns: The value returned by the response handler closure.
     ///
     /// - Throws: An error if the request fails or if the response handler throws.
-    #if compiler(<6.3)
-    @_lifetime(&self)
-    #endif
     public mutating func perform<Return: ~Copyable>(
         request: HTTPRequest,
         body: consuming HTTPClientRequestBody<RequestWriter>? = nil,
@@ -69,9 +66,6 @@ where
     /// - Returns: A tuple containing the HTTP response header and the collected response body data.
     ///
     /// - Throws: An error if the request fails, if the response body exceeds the limit, or if collection fails.
-    #if compiler(<6.3)
-    @_lifetime(&self)
-    #endif
     public mutating func get(
         url: URL,
         headerFields: HTTPFields = [:],
@@ -103,9 +97,6 @@ where
     /// - Returns: A tuple containing the HTTP response header and the collected response body data.
     ///
     /// - Throws: An error if the request fails, if the response body exceeds the limit, or if collection fails.
-    #if compiler(<6.3)
-    @_lifetime(&self)
-    #endif
     public mutating func post(
         url: URL,
         headerFields: HTTPFields = [:],
@@ -138,9 +129,6 @@ where
     /// - Returns: A tuple containing the HTTP response header and the collected response body data.
     ///
     /// - Throws: An error if the request fails, if the response body exceeds the limit, or if collection fails.
-    #if compiler(<6.3)
-    @_lifetime(&self)
-    #endif
     public mutating func put(
         url: URL,
         headerFields: HTTPFields = [:],
@@ -173,9 +161,6 @@ where
     /// - Returns: A tuple containing the HTTP response header and the collected response body data.
     ///
     /// - Throws: An error if the request fails, if the response body exceeds the limit, or if collection fails.
-    #if compiler(<6.3)
-    @_lifetime(&self)
-    #endif
     public mutating func delete(
         url: URL,
         headerFields: HTTPFields = [:],
@@ -208,9 +193,6 @@ where
     /// - Returns: A tuple containing the HTTP response header and the collected response body data.
     ///
     /// - Throws: An error if the request fails, if the response body exceeds the limit, or if collection fails.
-    #if compiler(<6.3)
-    @_lifetime(&self)
-    #endif
     public mutating func patch(
         url: URL,
         headerFields: HTTPFields = [:],

--- a/Sources/HTTPAPIs/Client/HTTPClient.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClient.swift
@@ -15,7 +15,7 @@
 ///
 /// ``HTTPClient`` provides asynchronous request execution with streaming request
 /// and response bodies.
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public protocol HTTPClient<RequestOptions>: Sendable, ~Copyable, ~Escapable {
     associatedtype RequestOptions: HTTPClientCapability.RequestOptions
 
@@ -51,9 +51,6 @@ public protocol HTTPClient<RequestOptions>: Sendable, ~Copyable, ~Escapable {
     /// - Returns: The value returned by the response handler closure.
     ///
     /// - Throws: An error if the request fails or if the response handler throws.
-    #if compiler(<6.3)
-    @_lifetime(&self)
-    #endif
     mutating func perform<Return: ~Copyable>(
         request: HTTPRequest,
         body: consuming HTTPClientRequestBody<RequestWriter>?,

--- a/Sources/HTTPAPIs/Client/HTTPClientCapability+RequestOptions.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClientCapability+RequestOptions.swift
@@ -12,7 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 /// The namespace for all protocols defining HTTP client capabilities.
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public enum HTTPClientCapability {
     /// The request options protocol.
     ///

--- a/Sources/HTTPAPIs/Client/HTTPClientCapability+TLSVersionSelection.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClientCapability+TLSVersionSelection.swift
@@ -13,7 +13,7 @@
 
 public import NetworkTypes
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension HTTPClientCapability {
     /// A protocol for HTTP request options that support TLS version constraints.
     public protocol TLSVersionSelection: RequestOptions {

--- a/Sources/HTTPAPIs/Client/HTTPClientRequestBody+Data.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClientRequestBody+Data.swift
@@ -17,7 +17,7 @@ public import struct FoundationEssentials.Data
 public import struct Foundation.Data
 #endif
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension HTTPClientRequestBody where Writer: ~Copyable {
     /// Creates a seekable request body from `Data`.
     ///

--- a/Sources/HTTPAPIs/Client/HTTPClientRequestBody.swift
+++ b/Sources/HTTPAPIs/Client/HTTPClientRequestBody.swift
@@ -50,7 +50,7 @@ import AsyncStreaming
 ///     // Handle the response
 /// }
 /// ```
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public struct HTTPClientRequestBody<Writer: AsyncWriter & ~Copyable>: Sendable
 where Writer.WriteElement == UInt8, Writer: SendableMetatype {
     /// The body can be asked to restart writing from an arbitrary offset.

--- a/Sources/HTTPAPIs/ConcludingAsyncReader+collect.swift
+++ b/Sources/HTTPAPIs/ConcludingAsyncReader+collect.swift
@@ -15,7 +15,7 @@ public import AsyncStreaming
 import BasicContainers
 public import ContainersPreview
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension ConcludingAsyncReader where Self: ~Copyable, Underlying: ~Copyable {
     /// Collects elements from the underlying async reader and returns both the processed result and final element.
     ///

--- a/Sources/HTTPAPIs/ConcludingAsyncReader.swift
+++ b/Sources/HTTPAPIs/ConcludingAsyncReader.swift
@@ -17,7 +17,7 @@
 /// provide a conclusive element after completing all reads. This is particularly useful
 /// for streams that have meaningful completion states beyond just terminating, such as
 /// HTTP responses that include headers after the reader finishes the body.
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public protocol ConcludingAsyncReader<Underlying, FinalElement>: ~Copyable, ~Escapable {
     /// The underlying asynchronous reader type that produces elements.
     associatedtype Underlying: AsyncReader, ~Copyable, ~Escapable

--- a/Sources/HTTPAPIs/ConcludingAsyncWriter.swift
+++ b/Sources/HTTPAPIs/ConcludingAsyncWriter.swift
@@ -17,7 +17,7 @@
 /// provide a conclusive element after writing completes. This is particularly useful
 /// for streams that have meaningful completion states, such as HTTP responses that need
 /// to finalize with optional trailers.
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public protocol ConcludingAsyncWriter<Underlying, FinalElement>: ~Copyable, ~Escapable {
     /// The underlying asynchronous writer type.
     associatedtype Underlying: AsyncWriter, ~Copyable, ~Escapable
@@ -47,7 +47,7 @@ public protocol ConcludingAsyncWriter<Underlying, FinalElement>: ~Copyable, ~Esc
     ) async throws -> Return
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension ConcludingAsyncWriter where Self: ~Copyable, Underlying: ~Copyable {
     /// Produces a final element using the underlying async writer without returning a separate value.
     ///
@@ -79,7 +79,7 @@ extension ConcludingAsyncWriter where Self: ~Copyable, Underlying: ~Copyable {
     }
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension ConcludingAsyncWriter where Self: ~Copyable, Underlying: ~Copyable {
     /// Writes a single element to the underlying writer and concludes with a final element.
     ///

--- a/Sources/HTTPAPIs/Server/HTTPServer.swift
+++ b/Sources/HTTPAPIs/Server/HTTPServer.swift
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 /// A protocol that defines the interface for an HTTP server.
 ///
 /// ``HTTPServer`` provides the contract for server implementations that accept

--- a/Sources/HTTPAPIs/Server/HTTPServerClosureRequestHandler.swift
+++ b/Sources/HTTPAPIs/Server/HTTPServerClosureRequestHandler.swift
@@ -34,7 +34,7 @@
 ///     }
 /// }
 /// ```
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public struct HTTPServerClosureRequestHandler<
     RequestReader: ConcludingAsyncReader & ~Copyable,
     ResponseWriter: ConcludingAsyncWriter & ~Copyable,
@@ -92,7 +92,7 @@ where
     }
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension HTTPServer
 where
     Self: ~Copyable,

--- a/Sources/HTTPAPIs/Server/HTTPServerRequestHandler.swift
+++ b/Sources/HTTPAPIs/Server/HTTPServerRequestHandler.swift
@@ -54,7 +54,7 @@
 ///     }
 /// }
 /// ```
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public protocol HTTPServerRequestHandler<RequestReader, ResponseWriter>: Sendable {
     /// The type used to read request body data and trailers.
     associatedtype RequestReader: ConcludingAsyncReader, ~Copyable

--- a/Sources/HTTPAPIs/Server/HTTPServerResponseSender.swift
+++ b/Sources/HTTPAPIs/Server/HTTPServerResponseSender.swift
@@ -18,7 +18,7 @@
 /// more times using ``sendInformational(_:)`` before sending the final response. This design
 /// enforces proper HTTP semantics: exactly one non-informational response, followed by
 /// optional response body streaming and trailers.
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public struct HTTPResponseSender<ResponseWriter: ConcludingAsyncWriter & ~Copyable>: ~Copyable where ResponseWriter.Underlying: ~Copyable {
     private let _sendInformational: (HTTPResponse) async throws -> Void
     private let _send: (HTTPResponse) async throws -> ResponseWriter

--- a/Sources/HTTPClient/DefaultHTTPClient.swift
+++ b/Sources/HTTPClient/DefaultHTTPClient.swift
@@ -21,13 +21,13 @@ public import BasicContainers
 #if canImport(Darwin)
 import URLSessionHTTPClient
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 typealias ActualHTTPClient = URLSessionHTTPClient
 #else
 import AsyncHTTPClient
 import AHCHTTPClient
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 typealias ActualHTTPClient = AsyncHTTPClient.HTTPClient
 #endif
 
@@ -36,7 +36,7 @@ typealias ActualHTTPClient = AsyncHTTPClient.HTTPClient
 /// `DefaultHTTPClient` provides an efficient HTTP client implementation that reuses
 /// connections across multiple requests. It supports HTTP/1.1, HTTP/2, and HTTP/3 protocols,
 /// automatically handling connection management, protocol negotiation, and resource cleanup.
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public final class DefaultHTTPClient: HTTPAPIs.HTTPClient {
     public struct RequestWriter: AsyncWriter, ~Copyable {
         public typealias WriteElement = UInt8

--- a/Sources/HTTPClient/HTTP+Conveniences.swift
+++ b/Sources/HTTPClient/HTTP+Conveniences.swift
@@ -36,7 +36,7 @@ extension HTTP {
     /// - Returns: The value returned by the response handler closure.
     ///
     /// - Throws: An error if the request fails or if the response handler throws.
-    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+    @available(anyAppleOS 26.0, *)
     public static func perform<Return: ~Copyable>(
         request: HTTPRequest,
         body: consuming HTTPClientRequestBody<DefaultHTTPClient.RequestWriter>? = nil,
@@ -62,7 +62,7 @@ extension HTTP {
     /// - Returns: A tuple containing the HTTP response header and the collected response body data.
     ///
     /// - Throws: An error if the request fails, if the response body exceeds the limit, or if collection fails.
-    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+    @available(anyAppleOS 26.0, *)
     public static func get(
         url: URL,
         headerFields: HTTPFields = [:],
@@ -90,7 +90,7 @@ extension HTTP {
     /// - Returns: A tuple containing the HTTP response header and the collected response body data.
     ///
     /// - Throws: An error if the request fails, if the response body exceeds the limit, or if collection fails.
-    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+    @available(anyAppleOS 26.0, *)
     public static func post(
         url: URL,
         headerFields: HTTPFields = [:],
@@ -119,7 +119,7 @@ extension HTTP {
     /// - Returns: A tuple containing the HTTP response header and the collected response body data.
     ///
     /// - Throws: An error if the request fails, if the response body exceeds the limit, or if collection fails.
-    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+    @available(anyAppleOS 26.0, *)
     public static func put(
         url: URL,
         headerFields: HTTPFields = [:],
@@ -148,7 +148,7 @@ extension HTTP {
     /// - Returns: A tuple containing the HTTP response header and the collected response body data.
     ///
     /// - Throws: An error if the request fails, if the response body exceeds the limit, or if collection fails.
-    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+    @available(anyAppleOS 26.0, *)
     public static func delete(
         url: URL,
         headerFields: HTTPFields = [:],
@@ -177,7 +177,7 @@ extension HTTP {
     /// - Returns: A tuple containing the HTTP response header and the collected response body data.
     ///
     /// - Throws: An error if the request fails, if the response body exceeds the limit, or if collection fails.
-    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+    @available(anyAppleOS 26.0, *)
     public static func patch(
         url: URL,
         headerFields: HTTPFields = [:],

--- a/Sources/HTTPClient/HTTPConnectionPoolConfiguration.swift
+++ b/Sources/HTTPClient/HTTPConnectionPoolConfiguration.swift
@@ -12,7 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Configuration options for an HTTP connection pool.
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public struct HTTPConnectionPoolConfiguration: Hashable, Sendable {
     /// The maximum number of concurrent HTTP/1.1 connections allowed per host.
     ///

--- a/Sources/HTTPClient/HTTPRequestOptions.swift
+++ b/Sources/HTTPClient/HTTPRequestOptions.swift
@@ -12,7 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 /// The options for the default HTTP client implementation.
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public struct HTTPRequestOptions: HTTPClientCapability.RequestOptions {
     public init() {}
 }

--- a/Sources/HTTPClientConformance/HTTPClientConformance.swift
+++ b/Sources/HTTPClientConformance/HTTPClientConformance.swift
@@ -73,7 +73,7 @@ public enum ConformanceTestCase: Sendable, Hashable, CaseIterable {
 
 // Runs an HTTP client through all the conformance tests,
 // except the ones specified in `excluding`.
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public func runConformanceTests<Client: HTTPClient & ~Copyable>(
     excluding: [ConformanceTestCase] = [],
     _ clientFactory: @escaping () async throws -> Client
@@ -104,7 +104,7 @@ public func runConformanceTests<Client: HTTPClient & ~Copyable>(
     }
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
     let testServerPort: Int
     let rawServerPort: Int

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/HTTPRequestConcludingAsyncReader.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/HTTPRequestConcludingAsyncReader.swift
@@ -25,7 +25,7 @@ import Synchronization
 /// and concluding with the HTTP trailer fields received at the end of the request. This type
 /// follows the ``ConcludingAsyncReader`` pattern, which allows for asynchronous consumption of
 /// a stream with a conclusive final element.
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public struct HTTPRequestConcludingAsyncReader: ConcludingAsyncReader, ~Copyable {
     /// A reader for HTTP request body chunks that implements the ``AsyncReader`` protocol.
     ///

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/HTTPResponseConcludingAsyncWriter.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/HTTPResponseConcludingAsyncWriter.swift
@@ -27,7 +27,7 @@ import Synchronization
 ///
 /// This writer is designed to work with HTTP responses where the body is streamed in chunks
 /// and potentially followed by trailer fields.
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public struct HTTPResponseConcludingAsyncWriter: ConcludingAsyncWriter, ~Copyable {
     /// A writer for HTTP response body chunks that implements the ``AsyncWriter`` protocol.
     ///

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer+ConnectionContext.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer+ConnectionContext.swift
@@ -15,7 +15,7 @@ import NIOCore
 import NIOSSL
 public import X509
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension NIOHTTPServer {
     /// Connection-specific information available during request handling.
     ///

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer+HTTP1_1.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer+HTTP1_1.swift
@@ -19,7 +19,7 @@ import NIOHTTPTypes
 import NIOHTTPTypesHTTP1
 import NIOPosix
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension NIOHTTPServer {
     func serveInsecureHTTP1_1(
         bindTarget: NIOHTTPServerConfiguration.BindTarget,

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer+ListeningAddress.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer+ListeningAddress.swift
@@ -34,7 +34,7 @@ enum ListeningAddressError: CustomStringConvertible, Error {
     }
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension NIOHTTPServer {
     func addressBound(_ address: NIOCore.SocketAddress?) throws {
         switch self.listeningAddressState.withLockedValue({ $0.addressBound(address) }) {
@@ -60,7 +60,7 @@ extension NIOHTTPServer {
     }
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension NIOHTTPServer {
     enum State {
         case idle(EventLoopPromise<SocketAddress>)
@@ -124,7 +124,7 @@ extension NIOHTTPServer {
     }
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension NIOHTTPServer.SocketAddress {
     fileprivate init(_ address: NIOCore.SocketAddress?) throws(ListeningAddressError) {
         guard let address, let port = address.port else {

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer+SecureUpgrade.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer+SecureUpgrade.swift
@@ -23,7 +23,7 @@ import NIOPosix
 import NIOSSL
 import X509
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension NIOHTTPServer {
     func serveSecureUpgrade(
         bindTarget: NIOHTTPServerConfiguration.BindTarget,
@@ -167,7 +167,7 @@ extension NIOHTTPServer {
     }
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension NIOHTTPServer {
     func makeSSLServerHandler(
         _ tlsConfiguration: TLSConfiguration,

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer+SwiftConfiguration.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer+SwiftConfiguration.swift
@@ -28,7 +28,7 @@ enum NIOHTTPServerConfigurationError: Error, CustomStringConvertible {
     }
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension NIOHTTPServerConfiguration {
     /// Initialize the server configuration from a config reader.
     ///
@@ -71,7 +71,7 @@ extension NIOHTTPServerConfiguration {
     }
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension NIOHTTPServerConfiguration.BindTarget {
     /// Initialize a bind target configuration from a config reader.
     ///
@@ -90,7 +90,7 @@ extension NIOHTTPServerConfiguration.BindTarget {
     }
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension NIOHTTPServerConfiguration.TransportSecurity {
     /// Initialize a transport security configuration from a config reader.
     ///
@@ -248,7 +248,7 @@ extension NIOHTTPServerConfiguration.TransportSecurity {
     }
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension NIOHTTPServerConfiguration.BackPressureStrategy {
     /// Initialize the backpressure strategy configuration from a config reader.
     ///
@@ -274,7 +274,7 @@ extension NIOHTTPServerConfiguration.BackPressureStrategy {
     }
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension NIOHTTPServerConfiguration.HTTP2 {
     /// Initialize a HTTP/2 configuration from a config reader.
     ///
@@ -304,7 +304,7 @@ extension NIOHTTPServerConfiguration.HTTP2 {
     }
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension NIOHTTPServerConfiguration.TransportSecurity {
     fileprivate enum TransportSecurityKind: String {
         case plaintext
@@ -331,7 +331,7 @@ extension NIOHTTPServerConfiguration.TransportSecurity {
     }
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension CertificateVerificationMode {
     fileprivate init(_ mode: NIOHTTPServerConfiguration.TransportSecurity.VerificationMode) {
         switch mode {

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer.swift
@@ -76,7 +76,7 @@ import X509
 ///     }
 /// }
 /// ```
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public struct NIOHTTPServer: HTTPServer {
     public typealias RequestConcludingReader = HTTPRequestConcludingAsyncReader
     public typealias ResponseConcludingWriter = HTTPResponseConcludingAsyncWriter
@@ -350,7 +350,7 @@ public struct NIOHTTPServer: HTTPServer {
     }
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension NIOHTTP2Handler.Configuration {
     init(httpServerHTTP2Configuration http2Config: NIOHTTPServerConfiguration.HTTP2) {
         let clampedTargetWindowSize = Self.clampTargetWindowSize(http2Config.targetWindowSize)

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServerConfiguration.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServerConfiguration.swift
@@ -20,7 +20,7 @@ public import X509
 ///
 /// This structure contains all the necessary configuration options for setting up
 /// and running ``NIOHTTPServer``, including network binding and TLS settings.
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public struct NIOHTTPServerConfiguration: Sendable {
     /// Specifies where the server should bind and listen for incoming connections.
     ///
@@ -310,7 +310,7 @@ public struct NIOHTTPServerConfiguration: Sendable {
 ///
 /// Indicates whether certificate verification succeeded or failed, and provides associated metadata when verification
 /// is successful.
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public enum CertificateVerificationResult: Sendable, Hashable {
     /// Metadata resulting from successful certificate verification.
     public struct VerificationMetadata: Sendable, Hashable {
@@ -376,7 +376,7 @@ public struct CertificateVerificationMode: Sendable {
     }
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension NIOSSL.CertificateVerification {
     /// Maps ``CertificateVerificationMode`` to the NIOSSL representation.
     init(_ verificationMode: CertificateVerificationMode) {

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/RawHTTPServer.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/RawHTTPServer.swift
@@ -16,7 +16,7 @@ import NIOCore
 import NIOHTTP1
 import NIOPosix
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public func withRawHTTPServer(perform: (Int) async throws -> Void) async throws {
     try await withThrowingTaskGroup {
         let server = try await RawHTTPServer()
@@ -103,7 +103,7 @@ func handler(request: HTTPRequestHead) -> Data {
     }
 }
 
-@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+@available(anyAppleOS 26.0, *)
 actor RawHTTPServer {
     let server_channel:
         NIOAsyncChannel<

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/RequestResponseMiddlewareBox.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/RequestResponseMiddlewareBox.swift
@@ -17,7 +17,7 @@ public import HTTPTypes
 /// This type holds the values passed to the ``HTTPServerRequestHandler`` when handling a request.
 ///
 /// It is necessary to box them together so that they can be used with `Middlewares`, as this will be the `Middleware.Input`.
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public struct RequestResponseMiddlewareBox<
     RequestReader: ConcludingAsyncReader & ~Copyable,
     ResponseWriter: ConcludingAsyncWriter & ~Copyable

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/SocketAddress.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/SocketAddress.swift
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension NIOHTTPServer {
     /// Represents an IPv4 address.
     public struct IPv4: Hashable, Sendable {

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/TestHTTPServer.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/TestHTTPServer.swift
@@ -44,7 +44,7 @@ struct JSONHTTPRequest: Codable {
     let trailers: [String: [String]]
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public func withTestHTTPServer(perform: (Int) async throws -> Void) async throws {
     try await withThrowingTaskGroup {
         let logger = Logger(label: "TestHTTPServer")
@@ -59,7 +59,7 @@ public func withTestHTTPServer(perform: (Int) async throws -> Void) async throws
     }
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 struct ETag: Sendable & ~Copyable {
     let eTag: Mutex<Int> = .init(0)
 
@@ -84,7 +84,7 @@ struct ETag: Sendable & ~Copyable {
     }
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 func serve(server: NIOHTTPServer) async throws {
     let eTag = ETag()
     try await server.serve { request, requestContext, requestBodyAndTrailers, responseSender in

--- a/Sources/URLSessionHTTPClient/HTTPClientCapability+DeclarativeTLSHandler.swift
+++ b/Sources/URLSessionHTTPClient/HTTPClientCapability+DeclarativeTLSHandler.swift
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension HTTPClientCapability {
     /// A protocol for HTTP request options that support TLS policies.
     public protocol DeclarativeTLS: RequestOptions {

--- a/Sources/URLSessionHTTPClient/HTTPClientCapability+RedirectionHandler.swift
+++ b/Sources/URLSessionHTTPClient/HTTPClientCapability+RedirectionHandler.swift
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension HTTPClientCapability {
     /// A protocol for HTTP request options that support custom redirection handling.
     public protocol RedirectionHandler: RequestOptions {
@@ -32,7 +32,7 @@ extension HTTPClientCapability {
     }
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension HTTPClientCapability.RedirectionHandler {
     /// The redirection handler closure to be invoked when a 3xx response is received and
     /// a redirection is about to be taken.

--- a/Sources/URLSessionHTTPClient/HTTPClientCapability+TLSSecurityHandler.swift
+++ b/Sources/URLSessionHTTPClient/HTTPClientCapability+TLSSecurityHandler.swift
@@ -14,7 +14,7 @@
 #if canImport(Darwin)
 import Security
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension HTTPClientCapability {
     /// A protocol for HTTP request options that support custom TLS callbacks.
     public protocol TLSSecurityHandler: RequestOptions, DeclarativeTLS {
@@ -42,7 +42,7 @@ extension HTTPClientCapability {
     }
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension HTTPClientCapability.TLSSecurityHandler {
     public var serverTrustPolicy: TrustEvaluationPolicy {
         get {

--- a/Sources/URLSessionHTTPClient/HTTPClientClientCertificateHandler.swift
+++ b/Sources/URLSessionHTTPClient/HTTPClientClientCertificateHandler.swift
@@ -25,7 +25,7 @@ public import Security
 /// The `Identifiable` conformance allows a Hashable identifier for guiding connection reuse.
 ///
 /// - SeeAlso: ``HTTPClientServerTrustHandler``
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public protocol HTTPClientClientCertificateHandler: Identifiable, Sendable {
     /// Handles a client certificate challenge from the server.
     ///

--- a/Sources/URLSessionHTTPClient/HTTPClientRedirectionAction.swift
+++ b/Sources/URLSessionHTTPClient/HTTPClientRedirectionAction.swift
@@ -15,7 +15,7 @@
 ///
 /// ``HTTPClientRedirectionAction`` specifies whether to follow a redirect to a new location
 /// or deliver the original redirect response to the caller.
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public enum HTTPClientRedirectionAction: Sendable {
     /// Follows the HTTP redirection by performing the new request.
     ///

--- a/Sources/URLSessionHTTPClient/HTTPClientRedirectionHandler.swift
+++ b/Sources/URLSessionHTTPClient/HTTPClientRedirectionHandler.swift
@@ -49,7 +49,7 @@
 /// ```
 ///
 /// - SeeAlso: ``HTTPClientRedirectionAction``
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public protocol HTTPClientRedirectionHandler: Sendable {
     /// Handles an HTTP redirection and determines the action to take.
     ///

--- a/Sources/URLSessionHTTPClient/HTTPClientServerTrustHandler.swift
+++ b/Sources/URLSessionHTTPClient/HTTPClientServerTrustHandler.swift
@@ -24,7 +24,7 @@ public import Security
 ///   policies like certificate pinning.
 ///
 /// - SeeAlso: ``TrustEvaluationResult``
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public protocol HTTPClientServerTrustHandler: Identifiable, Sendable {
     /// Evaluates the server's trust and determines whether to allow the connection.
     ///

--- a/Sources/URLSessionHTTPClient/HTTPTypeConversionError.swift
+++ b/Sources/URLSessionHTTPClient/HTTPTypeConversionError.swift
@@ -12,7 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(Darwin)
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 enum HTTPTypeConversionError: Error {
     case unsupportedScheme
     case failedToConvertHTTPTypesToURLType

--- a/Sources/URLSessionHTTPClient/IdleTimer.swift
+++ b/Sources/URLSessionHTTPClient/IdleTimer.swift
@@ -11,20 +11,20 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 protocol IdleTimerEntry: ~Copyable {
     var idleDuration: Duration? { get }
     func idleTimeoutFired()
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 protocol IdleTimerEntryProvider: ~Copyable {
     associatedtype Entry: IdleTimerEntry
     associatedtype Entries: Sequence<Entry>
     var idleTimerEntries: Entries { get }
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 enum IdleTimer {
     static func run(timeout: Duration, provider: some IdleTimerEntryProvider) async {
         do {

--- a/Sources/URLSessionHTTPClient/TLSVersion+tls_protocol_version_t.swift
+++ b/Sources/URLSessionHTTPClient/TLSVersion+tls_protocol_version_t.swift
@@ -15,7 +15,7 @@
 import NetworkTypes
 import Security
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension TLSVersion {
     var tlsProtocolVersion: tls_protocol_version_t? {
         switch self {

--- a/Sources/URLSessionHTTPClient/TrustEvaluationPolicy.swift
+++ b/Sources/URLSessionHTTPClient/TrustEvaluationPolicy.swift
@@ -12,7 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 /// An enumeration that represents the policy for the server trust evaluation during TLS handshakes.
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public enum TrustEvaluationPolicy: Hashable, Sendable {
     /// The default system policy.
     case `default`

--- a/Sources/URLSessionHTTPClient/TrustEvaluationResult.swift
+++ b/Sources/URLSessionHTTPClient/TrustEvaluationResult.swift
@@ -16,7 +16,7 @@
 ///
 /// ``TrustEvaluationResult`` specifies whether to use the system's default trust evaluation,
 /// explicitly allow the connection, or explicitly deny it.
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public enum TrustEvaluationResult {
     /// Uses the system's default trust evaluation for the server certificate.
     ///

--- a/Sources/URLSessionHTTPClient/URLSessionConnectionPoolConfiguration.swift
+++ b/Sources/URLSessionHTTPClient/URLSessionConnectionPoolConfiguration.swift
@@ -12,7 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Configuration options for an HTTP connection pool.
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public struct URLSessionConnectionPoolConfiguration: Hashable, Sendable {
     /// The maximum number of concurrent HTTP/1.1 connections allowed per host.
     ///

--- a/Sources/URLSessionHTTPClient/URLSessionHTTPClient.swift
+++ b/Sources/URLSessionHTTPClient/URLSessionHTTPClient.swift
@@ -21,7 +21,7 @@ import NetworkTypes
 import Synchronization
 
 /// The HTTPClient implementation backed by URLSession.
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public final class URLSessionHTTPClient: HTTPClient, IdleTimerEntryProvider {
     public struct RequestWriter: AsyncWriter, ~Copyable {
         public typealias WriteElement = UInt8

--- a/Sources/URLSessionHTTPClient/URLSessionRequestOptions.swift
+++ b/Sources/URLSessionHTTPClient/URLSessionRequestOptions.swift
@@ -15,7 +15,7 @@
 public import NetworkTypes
 
 /// The options for the URLSession HTTP client implementation.
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 public struct URLSessionRequestOptions:
     HTTPClientCapability.RedirectionHandler,
     HTTPClientCapability.TLSSecurityHandler,

--- a/Sources/URLSessionHTTPClient/URLSessionRequestStreamBridge.swift
+++ b/Sources/URLSessionHTTPClient/URLSessionRequestStreamBridge.swift
@@ -17,7 +17,7 @@ import BasicContainers
 import Foundation
 import Synchronization
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 final class URLSessionRequestStreamBridge: NSObject, StreamDelegate, Sendable {
     private weak let task: URLSessionTask?
 

--- a/Sources/URLSessionHTTPClient/URLSessionTaskDelegateBridge.swift
+++ b/Sources/URLSessionHTTPClient/URLSessionTaskDelegateBridge.swift
@@ -17,7 +17,7 @@ import Foundation
 import HTTPTypesFoundation
 import Synchronization
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 final class URLSessionTaskDelegateBridge: NSObject, Sendable, URLSessionDataDelegate {
     private enum Callback: Sendable {
         case response(URLResponse)

--- a/Tests/AsyncHTTPClientConformanceTests/Suite.swift
+++ b/Tests/AsyncHTTPClientConformanceTests/Suite.swift
@@ -17,7 +17,7 @@ import HTTPClientConformance
 import Testing
 
 @Suite struct AsyncHTTPClientTests {
-    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+    @available(anyAppleOS 26.0, *)
     @Test func conformance() async throws {
         var config = HTTPClient.Configuration()
         config.connectionPool.concurrentHTTP1ConnectionsPerHostSoftLimit = 1

--- a/Tests/HTTPAPIsTests/EchoTests.swift
+++ b/Tests/HTTPAPIsTests/EchoTests.swift
@@ -16,7 +16,7 @@ import Foundation
 import HTTPAPIs
 import Testing
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension TestClientAndServer {
     func echo() async throws {
         try await self.serve { request, requestContext, requestBodyAndTrailers, responseSender in
@@ -38,7 +38,7 @@ extension TestClientAndServer {
 @Suite("HTTP Client and Server Tests")
 struct HTTPClientAndServerTests {
     @Test("Simple echo test")
-    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+    @available(anyAppleOS 26.0, *)
     func simpleEcho() async throws {
         let clientAndServer = TestClientAndServer()
         try await withThrowingTaskGroup { group in

--- a/Tests/HTTPAPIsTests/Helpers/Disconnected.swift
+++ b/Tests/HTTPAPIsTests/Helpers/Disconnected.swift
@@ -11,7 +11,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6.1)
 // This is a helper type to move a non-Sendable value across isolation regions.
 @usableFromInline
 struct Disconnected<Value: ~Copyable>: ~Copyable, Sendable {
@@ -37,4 +36,3 @@ struct Disconnected<Value: ~Copyable>: ~Copyable, Sendable {
         return unsafe value
     }
 }
-#endif

--- a/Tests/HTTPAPIsTests/Helpers/HTTPClientAndServerTests.swift
+++ b/Tests/HTTPAPIsTests/Helpers/HTTPClientAndServerTests.swift
@@ -22,7 +22,7 @@ import Testing
 /// A test client and server.
 ///
 /// This type hooks up a client to a server in-process.
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 final class TestClientAndServer: HTTPClient, HTTPServer {
     struct RequestOptions: HTTPClientCapability.RequestOptions {
         init() {}

--- a/Tests/HTTPAPIsTests/Helpers/MultiProducerSingleConsumerAsyncChannel+AsyncReader+AsyncWriter.swift
+++ b/Tests/HTTPAPIsTests/Helpers/MultiProducerSingleConsumerAsyncChannel+AsyncReader+AsyncWriter.swift
@@ -16,7 +16,7 @@ public import AsyncStreaming
 public import BasicContainers
 public import ContainersPreview
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension MultiProducerSingleConsumerAsyncChannel: AsyncReader {
     public typealias ReadElement = Element
     public typealias ReadFailure = Failure
@@ -45,7 +45,7 @@ extension MultiProducerSingleConsumerAsyncChannel: AsyncReader {
     }
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension MultiProducerSingleConsumerAsyncChannel.Source: AsyncWriter where Element == UInt8 {
     public typealias WriteElement = Element
     public typealias WriteFailure = any Error

--- a/Tests/HTTPClientTests/DarwinHTTPClientTests.swift
+++ b/Tests/HTTPClientTests/DarwinHTTPClientTests.swift
@@ -26,7 +26,7 @@ let testsEnabled: Bool = {
 @Suite
 struct DarwinHTTPClientTests {
     @Test(.enabled(if: testsEnabled))
-    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+    @available(anyAppleOS 26.0, *)
     func conformance() async throws {
         try await runConformanceTests(excluding: [
             // TODO: URLSession client does not correctly handle cached response updates during revalidation.


### PR DESCRIPTION
Originally we bumped the version to 26.2 due to an Xcode bug, and there is no longer anything blocking this from back-deploying to 26.0