### PR TITLE
upgrade swift-async-algorithms to 1.1.4

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -44,7 +44,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/apple/swift-async-algorithms.git",
-            revision: "d0b4a06d0f173a2f3be27d3ea21b3c3aa18db440",
+            from: "1.1.4",
             traits: ["UnstableAsyncStreaming"]
         ),
         .package(url: "https://github.com/apple/swift-http-types.git", from: "1.5.1"),


### PR DESCRIPTION
### Motivation

Avoid pinning swift-async-algorithms to specific commit

### Modifications

Switch from pin to release.

### Result

No longer pinned

### Test Plan

N/A the release points to the same exact commit.