### PR TITLE
Add request context capability mechanism to HTTPServer

### DIFF
--- a/Examples/ExampleMiddleware/HTTPServerLoggingMiddleware.swift
+++ b/Examples/ExampleMiddleware/HTTPServerLoggingMiddleware.swift
@@ -23,6 +23,7 @@ public import Middleware
 /// This middleware is useful for debugging and monitoring HTTP traffic.
 @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 public struct HTTPServerLoggingMiddleware<
+    RequestContext: HTTPServerCapability.RequestContext,
     RequestConcludingAsyncReader: ConcludingAsyncReader & ~Copyable,
     ResponseConcludingAsyncWriter: ConcludingAsyncWriter & ~Copyable
 >: Middleware
@@ -36,8 +37,9 @@ where
     ResponseConcludingAsyncWriter.Underlying.WriteElement == UInt8,
     ResponseConcludingAsyncWriter.FinalElement == HTTPFields?
 {
-    public typealias Input = HTTPServerMiddlewareInput<RequestConcludingAsyncReader, ResponseConcludingAsyncWriter>
+    public typealias Input = HTTPServerMiddlewareInput<RequestContext, RequestConcludingAsyncReader, ResponseConcludingAsyncWriter>
     public typealias NextInput = HTTPServerMiddlewareInput<
+        RequestContext,
         HTTPRequestLoggingConcludingAsyncReader<RequestConcludingAsyncReader>,
         HTTPResponseLoggingConcludingAsyncWriter<ResponseConcludingAsyncWriter>
     >
@@ -117,11 +119,12 @@ extension Middleware where Input: ~Copyable, NextInput: ~Copyable {
     ///     .requestHandler()
     /// }
     /// ```
-    public func logging<RequestReader, ResponseWriter>(
+    public func logging<RequestContext, RequestReader, ResponseWriter>(
         logger: Logger
-    ) -> HTTPServerLoggingMiddleware<RequestReader, ResponseWriter>
+    ) -> HTTPServerLoggingMiddleware<RequestContext, RequestReader, ResponseWriter>
     where
-        Input == HTTPServerMiddlewareInput<RequestReader, ResponseWriter>,
+        Input == HTTPServerMiddlewareInput<RequestContext, RequestReader, ResponseWriter>,
+        RequestContext: HTTPServerCapability.RequestContext,
         RequestReader: ConcludingAsyncReader & ~Copyable & Escapable,
         RequestReader.Underlying: ~Copyable & Escapable,
         RequestReader.Underlying.ReadElement == UInt8,

--- a/Examples/ExampleMiddleware/HTTPServerLoggingMiddleware.swift
+++ b/Examples/ExampleMiddleware/HTTPServerLoggingMiddleware.swift
@@ -23,7 +23,7 @@ public import Middleware
 /// This middleware is useful for debugging and monitoring HTTP traffic.
 @available(anyAppleOS 26.0, *)
 public struct HTTPServerLoggingMiddleware<
-    RequestContext: HTTPServerCapability.RequestContext,
+    RequestContext: HTTPServerCapability.RequestContext & ~Copyable,
     RequestConcludingAsyncReader: ConcludingAsyncReader & ~Copyable,
     ResponseConcludingAsyncWriter: ConcludingAsyncWriter & ~Copyable
 >: Middleware
@@ -124,7 +124,7 @@ extension Middleware where Input: ~Copyable, NextInput: ~Copyable {
     ) -> HTTPServerLoggingMiddleware<RequestContext, RequestReader, ResponseWriter>
     where
         Input == HTTPServerMiddlewareInput<RequestContext, RequestReader, ResponseWriter>,
-        RequestContext: HTTPServerCapability.RequestContext,
+        RequestContext: HTTPServerCapability.RequestContext & ~Copyable,
         RequestReader: ConcludingAsyncReader & ~Copyable & Escapable,
         RequestReader.Underlying: ~Copyable & Escapable,
         RequestReader.Underlying.ReadElement == UInt8,

--- a/Examples/ExampleMiddleware/HTTPServerMiddlewareInput.swift
+++ b/Examples/ExampleMiddleware/HTTPServerMiddlewareInput.swift
@@ -21,11 +21,12 @@ public import HTTPAPIs
 /// convenient way to pass all request-handling components through the middleware chain.
 @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 public struct HTTPServerMiddlewareInput<
+    RequestContext: HTTPServerCapability.RequestContext,
     RequestReader: ConcludingAsyncReader & ~Copyable,
     ResponseWriter: ConcludingAsyncWriter & ~Copyable
 >: ~Copyable where RequestReader.Underlying: ~Copyable, ResponseWriter.Underlying: ~Copyable {
     private let request: HTTPRequest
-    private let requestContext: HTTPRequestContext
+    private let requestContext: RequestContext
     private let requestReader: RequestReader
     private let responseSender: HTTPResponseSender<ResponseWriter>
 
@@ -38,7 +39,7 @@ public struct HTTPServerMiddlewareInput<
     ///   - responseSender: A sender for transmitting the HTTP response and response body.
     public init(
         request: HTTPRequest,
-        requestContext: HTTPRequestContext,
+        requestContext: RequestContext,
         requestReader: consuming RequestReader,
         responseSender: consuming HTTPResponseSender<ResponseWriter>
     ) {
@@ -63,7 +64,7 @@ public struct HTTPServerMiddlewareInput<
         _ handler:
             (
                 HTTPRequest,
-                HTTPRequestContext,
+                RequestContext,
                 consuming RequestReader,
                 consuming HTTPResponseSender<ResponseWriter>
             ) async throws -> Return

--- a/Examples/ExampleMiddleware/HTTPServerMiddlewareInput.swift
+++ b/Examples/ExampleMiddleware/HTTPServerMiddlewareInput.swift
@@ -21,7 +21,7 @@ public import HTTPAPIs
 /// convenient way to pass all request-handling components through the middleware chain.
 @available(anyAppleOS 26.0, *)
 public struct HTTPServerMiddlewareInput<
-    RequestContext: HTTPServerCapability.RequestContext,
+    RequestContext: HTTPServerCapability.RequestContext & ~Copyable,
     RequestReader: ConcludingAsyncReader & ~Copyable,
     ResponseWriter: ConcludingAsyncWriter & ~Copyable
 >: ~Copyable where RequestReader.Underlying: ~Copyable, ResponseWriter.Underlying: ~Copyable {
@@ -39,7 +39,7 @@ public struct HTTPServerMiddlewareInput<
     ///   - responseSender: A sender for transmitting the HTTP response and response body.
     public init(
         request: HTTPRequest,
-        requestContext: RequestContext,
+        requestContext: consuming RequestContext,
         requestReader: consuming RequestReader,
         responseSender: consuming HTTPResponseSender<ResponseWriter>
     ) {
@@ -64,7 +64,7 @@ public struct HTTPServerMiddlewareInput<
         _ handler:
             (
                 HTTPRequest,
-                RequestContext,
+                consuming RequestContext,
                 consuming RequestReader,
                 consuming HTTPResponseSender<ResponseWriter>
             ) async throws -> Return

--- a/Examples/ExampleMiddleware/HTTPServerRequestHandlerMiddleware.swift
+++ b/Examples/ExampleMiddleware/HTTPServerRequestHandlerMiddleware.swift
@@ -21,6 +21,7 @@ public import Middleware
 /// This middleware has `Never` as its `NextInput` type, indicating it's the end of the chain.
 @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 public struct HTTPServerRequestHandlerMiddleware<
+    RequestContext: HTTPServerCapability.RequestContext,
     RequestConcludingAsyncReader: ConcludingAsyncReader & ~Copyable,
     ResponseConcludingAsyncWriter: ConcludingAsyncWriter & ~Copyable,
 >: Middleware, Sendable
@@ -32,7 +33,7 @@ where
     ResponseConcludingAsyncWriter.Underlying.WriteElement == UInt8,
     ResponseConcludingAsyncWriter.FinalElement == HTTPFields?
 {
-    public typealias Input = HTTPServerMiddlewareInput<RequestConcludingAsyncReader, ResponseConcludingAsyncWriter>
+    public typealias Input = HTTPServerMiddlewareInput<RequestContext, RequestConcludingAsyncReader, ResponseConcludingAsyncWriter>
     public typealias NextInput = Void
 
     /// Creates a new request handler middleware.
@@ -82,9 +83,10 @@ extension Middleware where Input: ~Copyable, NextInput: ~Copyable {
     ///     .requestHandler()
     /// }
     /// ```
-    public func requestHandler<RequestReader, ResponseWriter>() -> HTTPServerRequestHandlerMiddleware<RequestReader, ResponseWriter>
+    public func requestHandler<RequestContext, RequestReader, ResponseWriter>() -> HTTPServerRequestHandlerMiddleware<RequestContext, RequestReader, ResponseWriter>
     where
-        Input == HTTPServerMiddlewareInput<RequestReader, ResponseWriter>,
+        Input == HTTPServerMiddlewareInput<RequestContext, RequestReader, ResponseWriter>,
+        RequestContext: HTTPServerCapability.RequestContext,
         RequestReader: ConcludingAsyncReader & ~Copyable,
         RequestReader.Underlying: ~Copyable,
         RequestReader.Underlying.ReadElement == UInt8,

--- a/Examples/ExampleMiddleware/HTTPServerRequestHandlerMiddleware.swift
+++ b/Examples/ExampleMiddleware/HTTPServerRequestHandlerMiddleware.swift
@@ -83,7 +83,9 @@ extension Middleware where Input: ~Copyable, NextInput: ~Copyable {
     ///     .requestHandler()
     /// }
     /// ```
-    public func requestHandler<RequestContext, RequestReader, ResponseWriter>() -> HTTPServerRequestHandlerMiddleware<RequestContext, RequestReader, ResponseWriter>
+    public func requestHandler<RequestContext, RequestReader, ResponseWriter>() -> HTTPServerRequestHandlerMiddleware<
+        RequestContext, RequestReader, ResponseWriter
+    >
     where
         Input == HTTPServerMiddlewareInput<RequestContext, RequestReader, ResponseWriter>,
         RequestContext: HTTPServerCapability.RequestContext,

--- a/Examples/ExampleMiddleware/HTTPServerRequestHandlerMiddleware.swift
+++ b/Examples/ExampleMiddleware/HTTPServerRequestHandlerMiddleware.swift
@@ -21,7 +21,7 @@ public import Middleware
 /// This middleware has `Never` as its `NextInput` type, indicating it's the end of the chain.
 @available(anyAppleOS 26.0, *)
 public struct HTTPServerRequestHandlerMiddleware<
-    RequestContext: HTTPServerCapability.RequestContext,
+    RequestContext: HTTPServerCapability.RequestContext & ~Copyable,
     RequestConcludingAsyncReader: ConcludingAsyncReader & ~Copyable,
     ResponseConcludingAsyncWriter: ConcludingAsyncWriter & ~Copyable,
 >: Middleware, Sendable
@@ -88,7 +88,7 @@ extension Middleware where Input: ~Copyable, NextInput: ~Copyable {
     >
     where
         Input == HTTPServerMiddlewareInput<RequestContext, RequestReader, ResponseWriter>,
-        RequestContext: HTTPServerCapability.RequestContext,
+        RequestContext: HTTPServerCapability.RequestContext & ~Copyable,
         RequestReader: ConcludingAsyncReader & ~Copyable,
         RequestReader.Underlying: ~Copyable,
         RequestReader.Underlying.ReadElement == UInt8,

--- a/Examples/MiddlewareServer/ExampleMiddlewareServer.swift
+++ b/Examples/MiddlewareServer/ExampleMiddlewareServer.swift
@@ -29,7 +29,7 @@ where
     Server.ResponseConcludingWriter.Underlying: ~Copyable,
     ServerMiddleware.Input: ~Copyable,
     ServerMiddleware.NextInput: ~Copyable,
-    ServerMiddleware.Input == HTTPServerMiddlewareInput<Server.RequestConcludingReader, Server.ResponseConcludingWriter>
+    ServerMiddleware.Input == HTTPServerMiddlewareInput<Server.RequestContext, Server.RequestConcludingReader, Server.ResponseConcludingWriter>
 {
     typealias RequestConcludingReader = Server.RequestConcludingReader
     typealias ResponseConcludingWriter = Server.ResponseConcludingWriter
@@ -70,7 +70,7 @@ where
     Server.ResponseConcludingWriter: ~Copyable,
     Server.ResponseConcludingWriter.Underlying: ~Copyable
 {
-    typealias Input = HTTPServerMiddlewareInput<Server.RequestConcludingReader, Server.ResponseConcludingWriter>
+    typealias Input = HTTPServerMiddlewareInput<Server.RequestContext, Server.RequestConcludingReader, Server.ResponseConcludingWriter>
     typealias NextInput = Input
 
     func intercept<Return: ~Copyable>(

--- a/Sources/HTTPAPIs/Server/HTTPServer.swift
+++ b/Sources/HTTPAPIs/Server/HTTPServer.swift
@@ -17,7 +17,7 @@
 /// ``HTTPServer`` provides the contract for server implementations that accept
 /// incoming HTTP connections and process requests using a ``HTTPServerRequestHandler``.
 public protocol HTTPServer<RequestContext, RequestConcludingReader, ResponseConcludingWriter>: Sendable, ~Copyable, ~Escapable {
-    associatedtype RequestContext: HTTPServerCapability.RequestContext
+    associatedtype RequestContext: HTTPServerCapability.RequestContext, ~Copyable, ~Escapable
 
     /// The type used to read request body data and trailers.
     // TODO: Check if we should allow ~Escapable readers https://github.com/apple/swift-http-api-proposal/issues/13
@@ -54,6 +54,7 @@ public protocol HTTPServer<RequestContext, RequestConcludingReader, ResponseConc
     /// ```
     func serve<Handler: HTTPServerRequestHandler>(handler: Handler) async throws
     where
+        Handler.RequestContext: ~Copyable & ~Escapable,
         Handler.RequestContext == RequestContext,
         Handler.RequestReader == RequestConcludingReader,
         Handler.RequestReader: ~Copyable,

--- a/Sources/HTTPAPIs/Server/HTTPServer.swift
+++ b/Sources/HTTPAPIs/Server/HTTPServer.swift
@@ -17,6 +17,10 @@
 /// ``HTTPServer`` provides the contract for server implementations that accept
 /// incoming HTTP connections and process requests using a ``HTTPServerRequestHandler``.
 public protocol HTTPServer<RequestContext, RequestConcludingReader, ResponseConcludingWriter>: Sendable, ~Copyable, ~Escapable {
+    /// The type of context provided to request handlers for each incoming request.
+    ///
+    /// Server implementations define this type to carry per-request metadata that isn't part
+    /// of the HTTP message itself, such as connection information or routing state.
     associatedtype RequestContext: HTTPServerCapability.RequestContext, ~Copyable
 
     /// The type used to read request body data and trailers.

--- a/Sources/HTTPAPIs/Server/HTTPServer.swift
+++ b/Sources/HTTPAPIs/Server/HTTPServer.swift
@@ -17,7 +17,7 @@
 /// ``HTTPServer`` provides the contract for server implementations that accept
 /// incoming HTTP connections and process requests using a ``HTTPServerRequestHandler``.
 public protocol HTTPServer<RequestContext, RequestConcludingReader, ResponseConcludingWriter>: Sendable, ~Copyable, ~Escapable {
-    associatedtype RequestContext: HTTPServerCapability.RequestContext, ~Copyable, ~Escapable
+    associatedtype RequestContext: HTTPServerCapability.RequestContext, ~Copyable
 
     /// The type used to read request body data and trailers.
     // TODO: Check if we should allow ~Escapable readers https://github.com/apple/swift-http-api-proposal/issues/13
@@ -54,7 +54,7 @@ public protocol HTTPServer<RequestContext, RequestConcludingReader, ResponseConc
     /// ```
     func serve<Handler: HTTPServerRequestHandler>(handler: Handler) async throws
     where
-        Handler.RequestContext: ~Copyable & ~Escapable,
+        Handler.RequestContext: ~Copyable,
         Handler.RequestContext == RequestContext,
         Handler.RequestReader == RequestConcludingReader,
         Handler.RequestReader: ~Copyable,

--- a/Sources/HTTPAPIs/Server/HTTPServer.swift
+++ b/Sources/HTTPAPIs/Server/HTTPServer.swift
@@ -16,7 +16,9 @@
 ///
 /// ``HTTPServer`` provides the contract for server implementations that accept
 /// incoming HTTP connections and process requests using a ``HTTPServerRequestHandler``.
-public protocol HTTPServer<RequestConcludingReader, ResponseConcludingWriter>: Sendable, ~Copyable, ~Escapable {
+public protocol HTTPServer<RequestContext, RequestConcludingReader, ResponseConcludingWriter>: Sendable, ~Copyable, ~Escapable {
+    associatedtype RequestContext: HTTPServerCapability.RequestContext
+
     /// The type used to read request body data and trailers.
     // TODO: Check if we should allow ~Escapable readers https://github.com/apple/swift-http-api-proposal/issues/13
     associatedtype RequestConcludingReader: ConcludingAsyncReader, ~Copyable, SendableMetatype
@@ -52,6 +54,7 @@ public protocol HTTPServer<RequestConcludingReader, ResponseConcludingWriter>: S
     /// ```
     func serve<Handler: HTTPServerRequestHandler>(handler: Handler) async throws
     where
+        Handler.RequestContext == RequestContext,
         Handler.RequestReader == RequestConcludingReader,
         Handler.RequestReader: ~Copyable,
         Handler.ResponseWriter == ResponseConcludingWriter,

--- a/Sources/HTTPAPIs/Server/HTTPServerCapability+RequestContext.swift
+++ b/Sources/HTTPAPIs/Server/HTTPServerCapability+RequestContext.swift
@@ -12,12 +12,55 @@
 //===----------------------------------------------------------------------===//
 
 /// The namespace for all protocols defining HTTP server capabilities.
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+///
+/// `HTTPServerCapability` groups protocols that represent optional features a server can provide.
+/// Each capability protocol defines a set of properties or methods that a server's request context
+/// must implement. Libraries and middleware can constrain their generic parameters to require
+/// specific capabilities, enabling compile-time verification that a server supports the needed features.
+///
+/// ## Defining a capability
+///
+/// ```swift
+/// extension HTTPServerCapability {
+///     protocol ConnectionInfo: RequestContext {
+///         var remoteAddress: String? { get }
+///         var localAddress: String? { get }
+///     }
+/// }
+/// ```
+///
+/// ## Using a capability in middleware or handlers
+///
+/// ```swift
+/// func logConnection<S: HTTPServer>(server: S) async throws
+/// where S.RequestContext: HTTPServerCapability.ConnectionInfo {
+///     try await server.serve { request, context, body, sender in
+///         print("Request from: \(context.remoteAddress ?? "unknown")")
+///         // ...
+///     }
+/// }
+/// ```
+@available(anyAppleOS 26.0, *)
 public enum HTTPServerCapability {
-    /// The request context protocol.
+    /// A protocol that all server request contexts must conform to.
     ///
-    /// Child protocols define additional context that a subset of servers provide,
-    /// allowing libraries to depend on specific capabilities.
+    /// `RequestContext` is the base protocol for request contexts provided by HTTP servers.
+    /// Servers create a context for each incoming request and pass it to the request handler.
+    /// The context carries metadata about the request that isn't part of the HTTP message itself,
+    /// such as connection information, routing state, or server-specific data.
+    ///
+    /// Child protocols (capabilities) extend `RequestContext` with additional properties that
+    /// a subset of servers provide, allowing libraries to depend on specific capabilities
+    /// without coupling to a concrete server implementation.
+    ///
+    /// ## Implementing a custom context
+    ///
+    /// ```swift
+    /// struct MyServerContext: HTTPServerCapability.ConnectionInfo {
+    ///     var remoteAddress: String?
+    ///     var localAddress: String?
+    /// }
+    /// ```
     public protocol RequestContext: ~Copyable, ~Escapable {
     }
 }

--- a/Sources/HTTPAPIs/Server/HTTPServerCapability+RequestContext.swift
+++ b/Sources/HTTPAPIs/Server/HTTPServerCapability+RequestContext.swift
@@ -32,8 +32,8 @@
 /// ## Using a capability in middleware or handlers
 ///
 /// ```swift
-/// func logConnection<S: HTTPServer>(server: S) async throws
-/// where S.RequestContext: HTTPServerCapability.ConnectionInfo {
+/// func logConnection<Server: HTTPServer>(server: Server) async throws
+/// where Server.RequestContext: HTTPServerCapability.ConnectionInfo {
 ///     try await server.serve { request, context, body, sender in
 ///         print("Request from: \(context.remoteAddress ?? "unknown")")
 ///         // ...

--- a/Sources/HTTPAPIs/Server/HTTPServerCapability+RequestContext.swift
+++ b/Sources/HTTPAPIs/Server/HTTPServerCapability+RequestContext.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift HTTP API Proposal open source project
 //
-// Copyright (c) 2025 Apple Inc. and the Swift HTTP API Proposal project authors
+// Copyright (c) 2026 Apple Inc. and the Swift HTTP API Proposal project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -11,8 +11,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// The default request context for HTTP server implementations.
+/// The namespace for all protocols defining HTTP server capabilities.
 @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
-public struct HTTPRequestContext: HTTPServerCapability.RequestContext {
-    public init() {}
+public enum HTTPServerCapability {
+    /// The request context protocol.
+    ///
+    /// Child protocols define additional context that a subset of servers provide,
+    /// allowing libraries to depend on specific capabilities.
+    public protocol RequestContext: ~Copyable, ~Escapable {
+    }
 }

--- a/Sources/HTTPAPIs/Server/HTTPServerClosureRequestHandler.swift
+++ b/Sources/HTTPAPIs/Server/HTTPServerClosureRequestHandler.swift
@@ -36,7 +36,7 @@
 /// ```
 @available(anyAppleOS 26.0, *)
 public struct HTTPServerClosureRequestHandler<
-    RequestContext: HTTPServerCapability.RequestContext & ~Copyable & ~Escapable,
+    RequestContext: HTTPServerCapability.RequestContext & ~Copyable,
     RequestReader: ConcludingAsyncReader & ~Copyable,
     ResponseWriter: ConcludingAsyncWriter & ~Copyable,
 >: HTTPServerRequestHandler

--- a/Sources/HTTPAPIs/Server/HTTPServerClosureRequestHandler.swift
+++ b/Sources/HTTPAPIs/Server/HTTPServerClosureRequestHandler.swift
@@ -36,7 +36,7 @@
 /// ```
 @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 public struct HTTPServerClosureRequestHandler<
-    RequestContext: HTTPServerCapability.RequestContext,
+    RequestContext: HTTPServerCapability.RequestContext & ~Copyable & ~Escapable,
     RequestReader: ConcludingAsyncReader & ~Copyable,
     ResponseWriter: ConcludingAsyncWriter & ~Copyable,
 >: HTTPServerRequestHandler
@@ -53,7 +53,7 @@ where
     private let _handler:
         @Sendable (
             HTTPRequest,
-            RequestContext,
+            consuming RequestContext,
             consuming sending RequestReader,
             consuming sending HTTPResponseSender<ResponseWriter>
         ) async throws -> Void
@@ -67,7 +67,7 @@ where
         handler:
             @Sendable @escaping (
                 HTTPRequest,
-                RequestContext,
+                consuming RequestContext,
                 consuming sending RequestReader,
                 consuming sending HTTPResponseSender<ResponseWriter>
             ) async throws -> Void
@@ -86,7 +86,7 @@ where
     ///   - responseSender: An ``HTTPResponseSender`` to send the HTTP response.
     public func handle(
         request: HTTPRequest,
-        requestContext: RequestContext,
+        requestContext: consuming RequestContext,
         requestBodyAndTrailers: consuming sending RequestReader,
         responseSender: consuming sending HTTPResponseSender<ResponseWriter>
     ) async throws {
@@ -132,7 +132,7 @@ where
         handler:
             @Sendable @escaping (
                 _ request: HTTPRequest,
-                _ requestContext: RequestContext,
+                _ requestContext: consuming RequestContext,
                 _ requestBodyAndTrailers: consuming sending RequestConcludingReader,
                 _ responseSender: consuming sending HTTPResponseSender<ResponseConcludingWriter>
             ) async throws -> Void

--- a/Sources/HTTPAPIs/Server/HTTPServerClosureRequestHandler.swift
+++ b/Sources/HTTPAPIs/Server/HTTPServerClosureRequestHandler.swift
@@ -36,6 +36,7 @@
 /// ```
 @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 public struct HTTPServerClosureRequestHandler<
+    RequestContext: HTTPServerCapability.RequestContext,
     RequestReader: ConcludingAsyncReader & ~Copyable,
     ResponseWriter: ConcludingAsyncWriter & ~Copyable,
 >: HTTPServerRequestHandler
@@ -47,11 +48,12 @@ where
     RequestReader.FinalElement == HTTPFields?,
     ResponseWriter.FinalElement == HTTPFields?
 {
+
     /// The underlying closure that handles HTTP requests.
     private let _handler:
         @Sendable (
             HTTPRequest,
-            HTTPRequestContext,
+            RequestContext,
             consuming sending RequestReader,
             consuming sending HTTPResponseSender<ResponseWriter>
         ) async throws -> Void
@@ -65,7 +67,7 @@ where
         handler:
             @Sendable @escaping (
                 HTTPRequest,
-                HTTPRequestContext,
+                RequestContext,
                 consuming sending RequestReader,
                 consuming sending HTTPResponseSender<ResponseWriter>
             ) async throws -> Void
@@ -79,12 +81,12 @@ where
     ///
     /// - Parameters:
     ///   - request: The HTTP request headers and metadata.
-    ///   - requestContext: A ``HTTPRequestContext``.
+    ///   - requestContext: The request context provided by the server.
     ///   - requestBodyAndTrailers: A reader for accessing the request body data and trailing headers.
     ///   - responseSender: An ``HTTPResponseSender`` to send the HTTP response.
     public func handle(
         request: HTTPRequest,
-        requestContext: HTTPRequestContext,
+        requestContext: RequestContext,
         requestBodyAndTrailers: consuming sending RequestReader,
         responseSender: consuming sending HTTPResponseSender<ResponseWriter>
     ) async throws {
@@ -109,14 +111,14 @@ where
     /// - Parameters:
     ///   - handler: An async closure that processes HTTP requests. The closure receives:
     ///     - `HTTPRequest`: The incoming HTTP request with headers and metadata.
-    ///     - ``HTTPRequestContext``: The request's context.
+    ///     - `RequestContext`: The request context provided by the server.
     ///     - ``HTTPRequestConcludingAsyncReader``: An async reader for consuming the request body and trailers.
     ///     - ``HTTPResponseSender``: A non-copyable wrapper for a function that accepts an `HTTPResponse` and provides access to an ``HTTPResponseConcludingAsyncWriter``.
     ///
     /// ## Example
     ///
     /// ```swift
-    /// try await server.serve { request, bodyReader, responseSender in
+    /// try await server.serve { request, requestContext, bodyReader, responseSender in
     ///     // Process the request
     ///     let response = HTTPResponse(status: .ok)
     ///     let writer = try await responseSender.send(response)
@@ -130,7 +132,7 @@ where
         handler:
             @Sendable @escaping (
                 _ request: HTTPRequest,
-                _ requestContext: HTTPRequestContext,
+                _ requestContext: RequestContext,
                 _ requestBodyAndTrailers: consuming sending RequestConcludingReader,
                 _ responseSender: consuming sending HTTPResponseSender<ResponseConcludingWriter>
             ) async throws -> Void

--- a/Sources/HTTPAPIs/Server/HTTPServerRequestHandler.swift
+++ b/Sources/HTTPAPIs/Server/HTTPServerRequestHandler.swift
@@ -26,6 +26,7 @@
 ///
 /// ```swift
 /// struct EchoHandler<
+///     Context: HTTPServerCapability.RequestContext,
 ///     ConcludingRequestReader: ConcludingAsyncReader<RequestReader, HTTPFields?> & ~Copyable,
 ///     RequestReader: AsyncReader<UInt8, any Error> & ~Copyable,
 ///     ConcludingResponseWriter: ConcludingAsyncWriter<ResponseWriter, HTTPFields?> & ~Copyable,
@@ -33,7 +34,7 @@
 /// >: HTTPServerRequestHandler {
 ///     func handle(
 ///         request: HTTPRequest,
-///         requestContext: HTTPRequestContext,
+///         requestContext: Context,
 ///         requestBodyAndTrailers: consuming sending ConcludingRequestReader,
 ///         responseSender: consuming sending HTTPResponseSender<ConcludingResponseWriter>
 ///     ) async throws {
@@ -55,7 +56,10 @@
 /// }
 /// ```
 @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
-public protocol HTTPServerRequestHandler<RequestReader, ResponseWriter>: Sendable {
+public protocol HTTPServerRequestHandler<RequestContext, RequestReader, ResponseWriter>: Sendable {
+    /// The type of the request context provided by the server.
+    associatedtype RequestContext: HTTPServerCapability.RequestContext
+
     /// The type used to read request body data and trailers.
     associatedtype RequestReader: ConcludingAsyncReader, ~Copyable
     where RequestReader.Underlying: ~Copyable, RequestReader.Underlying.ReadElement == UInt8, RequestReader.FinalElement == HTTPFields?
@@ -76,7 +80,7 @@ public protocol HTTPServerRequestHandler<RequestReader, ResponseWriter>: Sendabl
     ///
     /// - Parameters:
     ///   - request: The HTTP request headers and metadata.
-    ///   - requestContext: A ``HTTPRequestContext`` carrying additional request information.
+    ///   - requestContext: A context carrying additional request information provided by the server.
     ///   - requestBodyAndTrailers: A reader for accessing the request body data and trailing headers.
     ///   - responseSender: An ``HTTPResponseSender`` that accepts an HTTP response and returns a writer for the
     ///     response body. The returned writer allows for incremental writing of the response body and supports trailers.
@@ -84,7 +88,7 @@ public protocol HTTPServerRequestHandler<RequestReader, ResponseWriter>: Sendabl
     /// - Throws: Any error encountered during request processing or response generation.
     func handle(
         request: HTTPRequest,
-        requestContext: HTTPRequestContext,
+        requestContext: RequestContext,
         requestBodyAndTrailers: consuming sending RequestReader,
         responseSender: consuming sending HTTPResponseSender<ResponseWriter>
     ) async throws

--- a/Sources/HTTPAPIs/Server/HTTPServerRequestHandler.swift
+++ b/Sources/HTTPAPIs/Server/HTTPServerRequestHandler.swift
@@ -58,7 +58,7 @@
 @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 public protocol HTTPServerRequestHandler<RequestContext, RequestReader, ResponseWriter>: Sendable {
     /// The type of the request context provided by the server.
-    associatedtype RequestContext: HTTPServerCapability.RequestContext
+    associatedtype RequestContext: HTTPServerCapability.RequestContext, ~Copyable, ~Escapable
 
     /// The type used to read request body data and trailers.
     associatedtype RequestReader: ConcludingAsyncReader, ~Copyable
@@ -88,7 +88,7 @@ public protocol HTTPServerRequestHandler<RequestContext, RequestReader, Response
     /// - Throws: Any error encountered during request processing or response generation.
     func handle(
         request: HTTPRequest,
-        requestContext: RequestContext,
+        requestContext: consuming RequestContext,
         requestBodyAndTrailers: consuming sending RequestReader,
         responseSender: consuming sending HTTPResponseSender<ResponseWriter>
     ) async throws

--- a/Sources/HTTPAPIs/Server/HTTPServerRequestHandler.swift
+++ b/Sources/HTTPAPIs/Server/HTTPServerRequestHandler.swift
@@ -58,7 +58,7 @@
 @available(anyAppleOS 26.0, *)
 public protocol HTTPServerRequestHandler<RequestContext, RequestReader, ResponseWriter>: Sendable {
     /// The type of the request context provided by the server.
-    associatedtype RequestContext: HTTPServerCapability.RequestContext, ~Copyable, ~Escapable
+    associatedtype RequestContext: HTTPServerCapability.RequestContext, ~Copyable
 
     /// The type used to read request body data and trailers.
     associatedtype RequestReader: ConcludingAsyncReader, ~Copyable

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/HTTPRequestContext.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/HTTPRequestContext.swift
@@ -11,7 +11,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// The default request context for HTTP server implementations.
+public import HTTPAPIs
+
 @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 public struct HTTPRequestContext: HTTPServerCapability.RequestContext {
     public init() {}

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer+HTTP1_1.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer+HTTP1_1.swift
@@ -23,7 +23,7 @@ import NIOPosix
 extension NIOHTTPServer {
     func serveInsecureHTTP1_1(
         bindTarget: NIOHTTPServerConfiguration.BindTarget,
-        handler: some HTTPServerRequestHandler<RequestConcludingReader, ResponseConcludingWriter>,
+        handler: some HTTPServerRequestHandler<HTTPRequestContext, RequestConcludingReader, ResponseConcludingWriter>,
         asyncChannelConfiguration: NIOAsyncChannel<HTTPRequestPart, HTTPResponsePart>.Configuration
     ) async throws {
         let serverChannel = try await self.setupHTTP1_1ServerChannel(
@@ -71,7 +71,7 @@ extension NIOHTTPServer {
 
     func _serveInsecureHTTP1_1(
         serverChannel: NIOAsyncChannel<NIOAsyncChannel<HTTPRequestPart, HTTPResponsePart>, Never>,
-        handler: some HTTPServerRequestHandler<RequestConcludingReader, ResponseConcludingWriter>
+        handler: some HTTPServerRequestHandler<HTTPRequestContext, RequestConcludingReader, ResponseConcludingWriter>
     ) async throws {
         try await withThrowingDiscardingTaskGroup { group in
             try await serverChannel.executeThenClose { inbound in

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer+SecureUpgrade.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer+SecureUpgrade.swift
@@ -28,7 +28,7 @@ extension NIOHTTPServer {
     func serveSecureUpgrade(
         bindTarget: NIOHTTPServerConfiguration.BindTarget,
         tlsConfiguration: TLSConfiguration,
-        handler: some HTTPServerRequestHandler<RequestConcludingReader, ResponseConcludingWriter>,
+        handler: some HTTPServerRequestHandler<HTTPRequestContext, RequestConcludingReader, ResponseConcludingWriter>,
         asyncChannelConfiguration: NIOAsyncChannel<HTTPRequestPart, HTTPResponsePart>.Configuration,
         http2Configuration: NIOHTTP2Handler.Configuration,
         verificationCallback: (@Sendable ([X509.Certificate]) async throws -> CertificateVerificationResult)? = nil
@@ -120,7 +120,7 @@ extension NIOHTTPServer {
 
     func _serveSecureUpgrade(
         serverChannel: NIOAsyncChannel<EventLoopFuture<NegotiatedChannel>, Never>,
-        handler: some HTTPServerRequestHandler<RequestConcludingReader, ResponseConcludingWriter>
+        handler: some HTTPServerRequestHandler<HTTPRequestContext, RequestConcludingReader, ResponseConcludingWriter>
     ) async throws {
         try await withThrowingDiscardingTaskGroup { group in
             try await serverChannel.executeThenClose { inbound in

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/NIOHTTPServer.swift
@@ -78,6 +78,7 @@ import X509
 /// ```
 @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 public struct NIOHTTPServer: HTTPServer {
+    public typealias RequestContext = HTTPRequestContext
     public typealias RequestConcludingReader = HTTPRequestConcludingAsyncReader
     public typealias ResponseConcludingWriter = HTTPResponseConcludingAsyncWriter
 
@@ -145,7 +146,7 @@ public struct NIOHTTPServer: HTTPServer {
     ///     handler: EchoHandler()
     /// )
     /// ```
-    public func serve(handler: some HTTPServerRequestHandler<RequestConcludingReader, ResponseConcludingWriter>) async throws {
+    public func serve(handler: some HTTPServerRequestHandler<HTTPRequestContext, RequestConcludingReader, ResponseConcludingWriter>) async throws {
         defer {
             switch self.listeningAddressState.withLockedValue({ $0.close() }) {
             case .failPromise(let promise, let error):
@@ -265,7 +266,7 @@ public struct NIOHTTPServer: HTTPServer {
 
     func handleRequestChannel(
         channel: NIOAsyncChannel<HTTPRequestPart, HTTPResponsePart>,
-        handler: some HTTPServerRequestHandler<RequestConcludingReader, ResponseConcludingWriter>
+        handler: some HTTPServerRequestHandler<HTTPRequestContext, RequestConcludingReader, ResponseConcludingWriter>
     ) async throws {
         do {
             try await channel

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/RequestResponseMiddlewareBox.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/RequestResponseMiddlewareBox.swift
@@ -19,22 +19,24 @@ public import HTTPTypes
 /// It is necessary to box them together so that they can be used with `Middlewares`, as this will be the `Middleware.Input`.
 @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 public struct RequestResponseMiddlewareBox<
+    RequestContext: HTTPServerCapability.RequestContext,
     RequestReader: ConcludingAsyncReader & ~Copyable,
     ResponseWriter: ConcludingAsyncWriter & ~Copyable
 >: ~Copyable {
     private let request: HTTPRequest
-    private let requestContext: HTTPRequestContext
+    private let requestContext: RequestContext
     private let requestReader: RequestReader
     private let responseSender: HTTPResponseSender<ResponseWriter>
 
     /// Create a new ``RequestResponseMiddlewareBox``.
     /// - Parameters:
     ///   - request: The `HTTPRequest`.
+    ///   - requestContext: The request context.
     ///   - requestReader: The `RequestReader`.
     ///   - responseSender: The ``HTTPResponseSender``.
     public init(
         request: HTTPRequest,
-        requestContext: HTTPRequestContext,
+        requestContext: RequestContext,
         requestReader: consuming RequestReader,
         responseSender: consuming HTTPResponseSender<ResponseWriter>
     ) {
@@ -51,7 +53,7 @@ public struct RequestResponseMiddlewareBox<
         _ handler:
             nonisolated(nonsending) (
                 HTTPRequest,
-                HTTPRequestContext,
+                RequestContext,
                 consuming RequestReader,
                 consuming HTTPResponseSender<ResponseWriter>
             ) async throws -> T

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/RequestResponseMiddlewareBox.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/RequestResponseMiddlewareBox.swift
@@ -19,7 +19,7 @@ public import HTTPTypes
 /// It is necessary to box them together so that they can be used with `Middlewares`, as this will be the `Middleware.Input`.
 @available(anyAppleOS 26.0, *)
 public struct RequestResponseMiddlewareBox<
-    RequestContext: HTTPServerCapability.RequestContext,
+    RequestContext: HTTPServerCapability.RequestContext & ~Copyable,
     RequestReader: ConcludingAsyncReader & ~Copyable,
     ResponseWriter: ConcludingAsyncWriter & ~Copyable
 >: ~Copyable {
@@ -36,7 +36,7 @@ public struct RequestResponseMiddlewareBox<
     ///   - responseSender: The ``HTTPResponseSender``.
     public init(
         request: HTTPRequest,
-        requestContext: RequestContext,
+        requestContext: consuming RequestContext,
         requestReader: consuming RequestReader,
         responseSender: consuming HTTPResponseSender<ResponseWriter>
     ) {
@@ -53,7 +53,7 @@ public struct RequestResponseMiddlewareBox<
         _ handler:
             nonisolated(nonsending) (
                 HTTPRequest,
-                RequestContext,
+                consuming RequestContext,
                 consuming RequestReader,
                 consuming HTTPResponseSender<ResponseWriter>
             ) async throws -> T

--- a/Tests/HTTPAPIsTests/Helpers/HTTPClientAndServerTests.swift
+++ b/Tests/HTTPAPIsTests/Helpers/HTTPClientAndServerTests.swift
@@ -21,7 +21,13 @@ import Testing
 
 @available(anyAppleOS 26.0, *)
 struct HTTPRequestContext: HTTPServerCapability.RequestContext {
-    init() {}
+    var remoteAddress: String?
+    var localAddress: String?
+
+    init(remoteAddress: String? = nil, localAddress: String? = nil) {
+        self.remoteAddress = remoteAddress
+        self.localAddress = localAddress
+    }
 }
 
 /// A test client and server.
@@ -252,7 +258,10 @@ final class TestClientAndServer: HTTPClient, HTTPServer {
             try await handler
                 .handle(
                     request: request.request,
-                    requestContext: .init(),
+                    requestContext: HTTPRequestContext(
+                        remoteAddress: "127.0.0.1:54321",
+                        localAddress: "0.0.0.0:8080"
+                    ),
                     requestBodyAndTrailers: requestReader,
                     responseSender: responseSender
                 )

--- a/Tests/HTTPAPIsTests/Helpers/HTTPClientAndServerTests.swift
+++ b/Tests/HTTPAPIsTests/Helpers/HTTPClientAndServerTests.swift
@@ -19,6 +19,11 @@ import HTTPTypes
 import Synchronization
 import Testing
 
+@available(anyAppleOS 26.0, *)
+struct HTTPRequestContext: HTTPServerCapability.RequestContext {
+    init() {}
+}
+
 /// A test client and server.
 ///
 /// This type hooks up a client to a server in-process.

--- a/Tests/HTTPAPIsTests/Helpers/HTTPClientAndServerTests.swift
+++ b/Tests/HTTPAPIsTests/Helpers/HTTPClientAndServerTests.swift
@@ -19,22 +19,21 @@ import HTTPTypes
 import Synchronization
 import Testing
 
-@available(anyAppleOS 26.0, *)
-struct HTTPRequestContext: HTTPServerCapability.RequestContext {
-    var remoteAddress: String?
-    var localAddress: String?
-
-    init(remoteAddress: String? = nil, localAddress: String? = nil) {
-        self.remoteAddress = remoteAddress
-        self.localAddress = localAddress
-    }
-}
-
 /// A test client and server.
 ///
 /// This type hooks up a client to a server in-process.
 @available(anyAppleOS 26.0, *)
 final class TestClientAndServer: HTTPClient, HTTPServer {
+    struct HTTPRequestContext: HTTPServerCapability.RequestContext {
+        var remoteAddress: String?
+        var localAddress: String?
+
+        init(remoteAddress: String? = nil, localAddress: String? = nil) {
+            self.remoteAddress = remoteAddress
+            self.localAddress = localAddress
+        }
+    }
+
     struct RequestOptions: HTTPClientCapability.RequestOptions {
         init() {}
     }

--- a/Tests/HTTPAPIsTests/Helpers/HTTPClientAndServerTests.swift
+++ b/Tests/HTTPAPIsTests/Helpers/HTTPClientAndServerTests.swift
@@ -120,6 +120,7 @@ final class TestClientAndServer: HTTPClient, HTTPServer {
 
     typealias RequestWriter = AsyncChannelConcludingAsyncWriter.Underlying
     typealias ResponseConcludingReader = AsyncChannelConcludingAsyncReader
+    typealias RequestContext = HTTPRequestContext
     typealias RequestConcludingReader = AsyncChannelConcludingAsyncReader
     typealias ResponseConcludingWriter = AsyncChannelConcludingAsyncWriter
 
@@ -164,7 +165,7 @@ final class TestClientAndServer: HTTPClient, HTTPServer {
     }
 
     func serve(
-        handler: some HTTPServerRequestHandler<AsyncChannelConcludingAsyncReader, AsyncChannelConcludingAsyncWriter>
+        handler: some HTTPServerRequestHandler<HTTPRequestContext, AsyncChannelConcludingAsyncReader, AsyncChannelConcludingAsyncWriter>
     ) async throws {
         try await withThrowingDiscardingTaskGroup { group in
             for await _ in self.stream {
@@ -184,7 +185,7 @@ final class TestClientAndServer: HTTPClient, HTTPServer {
 
     private static func handleRequest(
         request: consuming BufferedRequest,
-        handler: some HTTPServerRequestHandler<AsyncChannelConcludingAsyncReader, AsyncChannelConcludingAsyncWriter>
+        handler: some HTTPServerRequestHandler<HTTPRequestContext, AsyncChannelConcludingAsyncReader, AsyncChannelConcludingAsyncWriter>
     ) async throws {
         try await withThrowingTaskGroup { group in
             let trailersChannel = AsyncChannel<HTTPFields?>()

--- a/Tests/HTTPAPIsTests/ServerCapabilityTests.swift
+++ b/Tests/HTTPAPIsTests/ServerCapabilityTests.swift
@@ -15,80 +15,60 @@ import Foundation
 import HTTPAPIs
 import Testing
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(anyAppleOS 26.0, *)
 extension HTTPServerCapability {
     protocol ConnectionInfo: RequestContext {
         var remoteAddress: String? { get }
         var localAddress: String? { get }
-        var negotiatedProtocol: String? { get }
     }
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
-struct TestConnectionContext: HTTPServerCapability.ConnectionInfo {
-    var remoteAddress: String?
-    var localAddress: String?
-    var negotiatedProtocol: String?
-}
+@available(anyAppleOS 26.0, *)
+extension HTTPRequestContext: HTTPServerCapability.ConnectionInfo {}
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
-func connectionInfoHandler<S: HTTPServer>(
-    server: S
-) async throws
-where
-    S.RequestContext: HTTPServerCapability.ConnectionInfo,
-    S.RequestConcludingReader: ~Copyable,
-    S.RequestConcludingReader.Underlying: ~Copyable,
-    S.ResponseConcludingWriter: ~Copyable,
-    S.ResponseConcludingWriter.Underlying: ~Copyable
-{
-    try await server.serve { request, requestContext, requestBodyAndTrailers, responseSender in
-        let remote = requestContext.remoteAddress ?? "unknown"
-        let responseBodyAndTrailers = try await responseSender.send(.init(status: .ok))
-        try await responseBodyAndTrailers.writeAndConclude(remote.utf8.span, finalElement: nil)
-    }
-}
+@available(anyAppleOS 26.0, *)
+extension TestClientAndServer {
+    func serveWithContextAssertions() async throws {
+        try await self.serve { request, requestContext, requestBodyAndTrailers, responseSender in
+            #expect(requestContext.remoteAddress == "127.0.0.1:54321")
+            #expect(requestContext.localAddress == "0.0.0.0:8080")
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
-struct ConnectionInfoTestServer: HTTPServer {
-    typealias RequestContext = TestConnectionContext
-    typealias RequestConcludingReader = TestClientAndServer.AsyncChannelConcludingAsyncReader
-    typealias ResponseConcludingWriter = TestClientAndServer.AsyncChannelConcludingAsyncWriter
-
-    let context: TestConnectionContext
-
-    init(context: TestConnectionContext) {
-        self.context = context
-    }
-
-    func serve<Handler: HTTPServerRequestHandler>(handler: Handler) async throws
-    where
-        Handler.RequestContext == TestConnectionContext,
-        Handler.RequestReader == RequestConcludingReader,
-        Handler.RequestReader: ~Copyable,
-        Handler.ResponseWriter == ResponseConcludingWriter,
-        Handler.ResponseWriter: ~Copyable
-    {
-        // This test just verifies the capability constraint compiles and the
-        // context is accessible. A full integration test would wire up connections.
+            let responseBodyAndTrailers = try await responseSender.send(.init(status: .ok))
+            try await responseBodyAndTrailers.writeAndConclude("".utf8.span, finalElement: nil)
+        }
     }
 }
 
 @Suite("Server Capability Tests")
 struct ServerCapabilityTests {
-    @Test("ConnectionInfo capability constraint compiles and context is accessible")
-    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+    @Test("RequestContext values flow through to handler")
+    @available(anyAppleOS 26.0, *)
     func connectionInfoCapability() async throws {
-        let context = TestConnectionContext(
-            remoteAddress: "127.0.0.1:54321",
-            localAddress: "0.0.0.0:8080",
-            negotiatedProtocol: "h2"
-        )
+        let clientAndServer = TestClientAndServer()
+        try await withThrowingTaskGroup { group in
+            group.addTask {
+                try await clientAndServer.serveWithContextAssertions()
+            }
 
-        // Verify a server with ConnectionInfo context can be passed to a
-        // function requiring that capability
-        let server = ConnectionInfoTestServer(context: context)
-        try await connectionInfoHandler(server: server)
+            let request = HTTPRequest(
+                method: .get,
+                scheme: "http",
+                authority: nil,
+                path: nil
+            )
+            var client = clientAndServer
+            try await client.perform(
+                request: request,
+                body: nil
+            ) { response, responseBodyAndTrailers in
+                #expect(response.status == .ok)
+                _ = try await responseBodyAndTrailers.consumeAndConclude { reader in
+                    var reader = reader
+                    try await reader.collect(upTo: 100) { _ in }
+                }
+            }
+
+            group.cancelAll()
+        }
     }
-
 }

--- a/Tests/HTTPAPIsTests/ServerCapabilityTests.swift
+++ b/Tests/HTTPAPIsTests/ServerCapabilityTests.swift
@@ -24,7 +24,7 @@ extension HTTPServerCapability {
 }
 
 @available(anyAppleOS 26.0, *)
-extension HTTPRequestContext: HTTPServerCapability.ConnectionInfo {}
+extension TestClientAndServer.HTTPRequestContext: HTTPServerCapability.ConnectionInfo {}
 
 @available(anyAppleOS 26.0, *)
 extension TestClientAndServer {

--- a/Tests/HTTPAPIsTests/ServerCapabilityTests.swift
+++ b/Tests/HTTPAPIsTests/ServerCapabilityTests.swift
@@ -1,0 +1,94 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP API Proposal open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift HTTP API Proposal project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import HTTPAPIs
+import Testing
+
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+extension HTTPServerCapability {
+    protocol ConnectionInfo: RequestContext {
+        var remoteAddress: String? { get }
+        var localAddress: String? { get }
+        var negotiatedProtocol: String? { get }
+    }
+}
+
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+struct TestConnectionContext: HTTPServerCapability.ConnectionInfo {
+    var remoteAddress: String?
+    var localAddress: String?
+    var negotiatedProtocol: String?
+}
+
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+func connectionInfoHandler<S: HTTPServer>(
+    server: S
+) async throws
+where
+    S.RequestContext: HTTPServerCapability.ConnectionInfo,
+    S.RequestConcludingReader: ~Copyable,
+    S.RequestConcludingReader.Underlying: ~Copyable,
+    S.ResponseConcludingWriter: ~Copyable,
+    S.ResponseConcludingWriter.Underlying: ~Copyable
+{
+    try await server.serve { request, requestContext, requestBodyAndTrailers, responseSender in
+        let remote = requestContext.remoteAddress ?? "unknown"
+        let responseBodyAndTrailers = try await responseSender.send(.init(status: .ok))
+        try await responseBodyAndTrailers.writeAndConclude(remote.utf8.span, finalElement: nil)
+    }
+}
+
+@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+struct ConnectionInfoTestServer: HTTPServer {
+    typealias RequestContext = TestConnectionContext
+    typealias RequestConcludingReader = TestClientAndServer.AsyncChannelConcludingAsyncReader
+    typealias ResponseConcludingWriter = TestClientAndServer.AsyncChannelConcludingAsyncWriter
+
+    let context: TestConnectionContext
+
+    init(context: TestConnectionContext) {
+        self.context = context
+    }
+
+    func serve<Handler: HTTPServerRequestHandler>(handler: Handler) async throws
+    where
+        Handler.RequestContext == TestConnectionContext,
+        Handler.RequestReader == RequestConcludingReader,
+        Handler.RequestReader: ~Copyable,
+        Handler.ResponseWriter == ResponseConcludingWriter,
+        Handler.ResponseWriter: ~Copyable
+    {
+        // This test just verifies the capability constraint compiles and the
+        // context is accessible. A full integration test would wire up connections.
+    }
+}
+
+@Suite("Server Capability Tests")
+struct ServerCapabilityTests {
+    @Test("ConnectionInfo capability constraint compiles and context is accessible")
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+    func connectionInfoCapability() async throws {
+        let context = TestConnectionContext(
+            remoteAddress: "127.0.0.1:54321",
+            localAddress: "0.0.0.0:8080",
+            negotiatedProtocol: "h2"
+        )
+
+        // Verify a server with ConnectionInfo context can be passed to a
+        // function requiring that capability
+        let server = ConnectionInfoTestServer(context: context)
+        try await connectionInfoHandler(server: server)
+    }
+
+}


### PR DESCRIPTION
Introduce HTTPServerCapability namespace with a base RequestContext protocol, mirroring the client-side HTTPClientCapability.RequestOptions pattern. Servers declare a RequestContext associated type that handlers can constrain to require specific capabilities (e.g. connection info, peer certificates) at compile time.

### Motivation

Clean up the client/server asymmetry. Afford the server APIs the same generic mechanism for requiring server capabilities.

### Modifications

Added HTTPServerCapability.RequestContext protocol.

### Result

Middleware and request handlers can now require server capabilities

### Test Plan

Added a basic unit test to demonstrate the pattern.