### PR TITLE
Make AHCHTTPClient.HTTPClient.Reader's init public

### DIFF
--- a/Sources/AHCHTTPClient/AHC+HTTPClient.swift
+++ b/Sources/AHCHTTPClient/AHC+HTTPClient.swift
@@ -101,7 +101,7 @@ extension AsyncHTTPClient.HTTPClient: HTTPAPIs.HTTPClient {
         var buffer = UniqueArray<UInt8>()
         var trailersDelivered: Bool = false
 
-        init(body: HTTPClientResponse.Body) {
+        public init(body: HTTPClientResponse.Body) {
             self.body = body
             self.underlying = body.makeAsyncIterator()
         }


### PR DESCRIPTION
The Reader struct already exposes a public AsyncReader conformance, but its `init(body:)` was internal — so callers outside AHCHTTPClient could spell the type but couldn't construct one. Promoting the init to public lets out-of-package adapters wrap an `HTTPClientResponse.Body` directly.