### PR TITLE
Update dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.6.0"),
         .package(
             url: "https://github.com/apple/swift-async-algorithms.git",
-            revision: "8ee3d2be1961950f94b6fa758477e3a0c5486aa9",
+            exact: "1.1.5",
             traits: ["UnstableAsyncStreaming"]
         ),
         .package(url: "https://github.com/apple/swift-http-types.git", from: "1.6.0"),
@@ -51,8 +51,9 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.44.0"),
         .package(url: "https://github.com/apple/swift-configuration.git", from: "1.2.0"),
         .package(
-            url: "https://github.com/swift-server/async-http-client.git",
-            revision: "a0ab90739bc856e7a097da8a4e71794aaaec651f"
+            url: "https://github.com/guoye-zhang/async-http-client.git",
+            revision: "ea8eccfb2cef417914ad50feec4814a14e7bbab5",
+            traits: ["ExperimentalHTTPAPIsSupport"]
         ),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -51,9 +51,9 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.44.0"),
         .package(url: "https://github.com/apple/swift-configuration.git", from: "1.2.0"),
         .package(
-            url: "https://github.com/guoye-zhang/async-http-client.git",
-            revision: "ea8eccfb2cef417914ad50feec4814a14e7bbab5",
-            traits: ["ExperimentalHTTPAPIsSupport"]
+            url: "https://github.com/swift-server/async-http-client.git",
+            exact: "1.35.0",
+            traits: ["UnstableHTTPAPIsSupport"]
         ),
     ],
     targets: [

--- a/Sources/AHCHTTPClient/AHC+HTTPClient.swift
+++ b/Sources/AHCHTTPClient/AHC+HTTPClient.swift
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(ExperimentalHTTPAPIsSupport) public import AsyncHTTPClient
+public import AsyncHTTPClient
 public import BasicContainers
 import Foundation
 @_exported public import HTTPAPIs

--- a/Sources/HTTPClientConformance/HTTPClientConformance.swift
+++ b/Sources/HTTPClientConformance/HTTPClientConformance.swift
@@ -898,8 +898,6 @@ struct ConformanceTestSuite<Client: HTTPClient & ~Copyable> {
         )
 
         // Read only a single byte from the body. We do not care about the rest of the 1Mb.
-        // The upstream `collect(upTo:)` now throws `AsyncReaderLeftOverElementsError`
-        // when the reader produces more elements than the limit, so we tolerate it.
         try await client.perform(
             request: request,
         ) { response, responseBodyAndTrailers in

--- a/Sources/HTTPClientConformance/HTTPServerForTesting/TestHTTPServer.swift
+++ b/Sources/HTTPClientConformance/HTTPServerForTesting/TestHTTPServer.swift
@@ -131,9 +131,9 @@ func serve(server: NIOHTTPServer) async throws {
             }
 
             // Parse the body as a UTF8 string and capture trailers
-            let (body, requestTrailers) = try await requestReader.collect(upTo: 1_000_000) { span in
-                String(copying: try UTF8Span(validating: span.span))
-            }
+            var bodyBuffer = UniqueArray<UInt8>(minimumCapacity: 1_000_000)
+            let requestTrailers = try await requestReader.collect(into: &bodyBuffer)
+            let body = String(copying: try UTF8Span(validating: bodyBuffer.span))
 
             // Collect the trailers that were sent in with the request
             var trailers: [String: [String]] = [:]

--- a/Tests/HTTPAPIsTests/ServerCapabilityTests.swift
+++ b/Tests/HTTPAPIsTests/ServerCapabilityTests.swift
@@ -62,7 +62,8 @@ struct ServerCapabilityTests {
                 body: nil
             ) { response, reader in
                 #expect(response.status == .ok)
-                _ = try await reader.collect(upTo: 100) { _ in }
+                var buffer = UniqueArray<UInt8>(minimumCapacity: 100)
+                _ = try await reader.collect(into: &buffer)
             }
 
             group.cancelAll()


### PR DESCRIPTION
Pin to swift-async-algorithms 1.1.5. Also waiting for https://github.com/swift-server/async-http-client/pull/911 to land and tag.