### PR TITLE
Disable Swift Configuration Traits

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -49,7 +49,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.37.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.34.1"),
         .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.44.0"),
-        .package(url: "https://github.com/apple/swift-configuration.git", from: "1.2.0"),
+        .package(url: "https://github.com/apple/swift-configuration.git", from: "1.2.0", traits: []),
         .package(
             url: "https://github.com/swift-server/async-http-client.git",
             exact: "1.35.0",


### PR DESCRIPTION
### Motivation

Swift Configuration's default traits pull in full Foundation because they enable the JSON configuration provider, which uses JSONSerialization. That undoes all the hard work in the library to only use FoundationEssentials as full foundation will be linked anyway. Since the HTTP APIs doesn't need any of the trait-hidden code, let's not include them.

Related to https://github.com/swift-server/swift-http-server/pull/109

### Modifications

Don't link full Foundation

### Result

Downstream packages won't be forced to include the full Foundation

### Test Plan

Compilation is enough
